### PR TITLE
Add nacl.random(N) to generate a random N bytes

### DIFF
--- a/nacl/__init__.py
+++ b/nacl/__init__.py
@@ -1,8 +1,9 @@
 from . import __about__
 from . import hash  # pylint: disable=W0622
+from .random import random
 
 
-__all__ = ["hash"] + __about__.__all__
+__all__ = ["hash", "random"] + __about__.__all__
 
 
 # - Meta Information -

--- a/nacl/nacl.py
+++ b/nacl/nacl.py
@@ -23,6 +23,11 @@ ffi.cdef(
         int crypto_hash_sha256(unsigned char *out, const unsigned char *in, unsigned long long inlen);
         int crypto_hash_sha512(unsigned char *out, const unsigned char *in, unsigned long long inlen);
     """
+
+    # Secure Random
+    """
+        void randombytes(unsigned char * const buf, const unsigned long long buf_len);
+    """
 )
 
 
@@ -37,6 +42,11 @@ try:
             #include "crypto_hash.h"
             #include "crypto_hash_sha256.h"
             #include "crypto_hash_sha512.h"
+        """
+
+        # Secure Random
+        """
+            #include "randombytes.h"
         """,
         libraries=["nacl"],
     )

--- a/nacl/random.py
+++ b/nacl/random.py
@@ -1,0 +1,7 @@
+from . import nacl
+
+
+def random(size=32):
+    data = nacl.ffi.new("unsigned char[]", size)
+    nacl.lib.randombytes(data, size)
+    return nacl.ffi.string(data)

--- a/tests/test_random.py
+++ b/tests/test_random.py
@@ -1,0 +1,9 @@
+import nacl
+
+
+def test_random_bytes_produces():
+    assert len(nacl.random(16)) == 16
+
+
+def test_random_bytes_produces_different_bytes():
+    assert nacl.random(16) != nacl.random(16)


### PR DESCRIPTION
Provides a simple interface to NaCl's random_bytes function.
