### PR TITLE
Properly handle strings with internal nul

### DIFF
--- a/nacl/hash.py
+++ b/nacl/hash.py
@@ -8,7 +8,7 @@ def sha256(message, binary=False):
     digest = nacl.ffi.new("unsigned char[]", nacl.lib.crypto_hash_sha256_BYTES)
     if not nacl.lib.crypto_hash_sha256(digest, message, len(message)):
         raise CryptoError("Hashing failed")
-    digest = nacl.ffi.string(digest)
+    digest = nacl.ffi.buffer(digest, nacl.lib.crypto_hash_sha256_BYTES)[:]
 
     if binary:
         return digest
@@ -19,7 +19,7 @@ def sha512(message, binary=False):
     digest = nacl.ffi.new("unsigned char[]", nacl.lib.crypto_hash_sha512_BYTES)
     if not nacl.lib.crypto_hash_sha512(digest, message, len(message)):
         raise CryptoError("Hashing failed")
-    digest = nacl.ffi.string(digest)
+    digest = nacl.ffi.buffer(digest, nacl.lib.crypto_hash_sha512_BYTES)[:]
 
     if binary:
         return digest

--- a/nacl/random.py
+++ b/nacl/random.py
@@ -4,4 +4,4 @@ from . import nacl
 def random(size=32):
     data = nacl.ffi.new("unsigned char[]", size)
     nacl.lib.randombytes(data, size)
-    return nacl.ffi.string(data)
+    return nacl.ffi.buffer(data, size)[:]


### PR DESCRIPTION
The strings from NaCl can contain nul characters inside the string and are not nul terminated. Using ffi.buffer with an explict size will prevent issues here.
