### PR TITLE
Remove support for libnacl leaving only libsodium

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,13 +8,11 @@ python:
 install:
   - sudo apt-get -q install python-pip
   - sudo /usr/bin/pip -q install git+git://github.com/pyinvoke/invoke.git
-  - invoke install-nacl --library=$NACL
-  - invoke install --dev
+  - invoke install.sodium
+  - invoke install.requirements --dev
 script:
   - invoke tests
 env:
   global:
     - LD_LIBRARY_PATH=/usr/local/lib
     - LD_RUN_PATH=/usr/local/lib
-  matrix:
-    - NACL=libsodium

--- a/nacl/nacl.py
+++ b/nacl/nacl.py
@@ -3,7 +3,7 @@ CFFI interface to NaCl and libsodium library
 """
 import functools
 
-from cffi import FFI, VerificationError
+from cffi import FFI
 
 
 __all__ = ["ffi", "lib"]
@@ -31,28 +31,7 @@ ffi.cdef(
 )
 
 
-# Check to make sure that we have a compiled interface to one of our library
-#   backends. We prefer NaCl here because it has compiled speed ups.
-# TODO: Include some way to specify which backend you want and hard fail if
-#   that one doesn't exist?
-try:
-    # Try to compile the ffi interface with NaCl
-    lib = ffi.verify(
-        """
-            #include "crypto_hash.h"
-            #include "crypto_hash_sha256.h"
-            #include "crypto_hash_sha512.h"
-        """
-
-        # Secure Random
-        """
-            #include "randombytes.h"
-        """,
-        libraries=["nacl"],
-    )
-except VerificationError:
-    # Try to compile the ffi interface with libsodium if NaCl wasn't available
-    lib = ffi.verify("#include <sodium.h>", libraries=["sodium"])
+lib = ffi.verify("#include <sodium.h>", libraries=["sodium"])
 
 
 # A lot of the functions in nacl return 0 for success and a negative integer

--- a/tasks.py
+++ b/tasks.py
@@ -5,77 +5,50 @@ import urllib2
 from invoke import task, run
 
 
-def download(url, hash, path):
-    resp = urllib2.urlopen(url)
+LIBSODIUM_VERSION = "0.2"
+LIBSODIUM_URL = "http://download.dnscrypt.org/libsodium/releases/libsodium-0.2.tar.gz"
+LIBSODIUM_HASH = b"e99a6b69adc080a5acf6b8a49fdc74b61d6f3579b590e85c93446a8325dde100"
+
+
+@task(aliases=["install.sodium"])
+def install_sodium():
+    tarball_path = os.path.expanduser(
+                        "~/libsodium-{}.tar.gz".format(LIBSODIUM_VERSION),
+                    )
+
+    # Download libsodium and verify it's hash
+    resp = urllib2.urlopen(LIBSODIUM_URL)
     content = resp.read()
     content_hash = hashlib.sha256(content).hexdigest()
-    assert hash == content_hash
 
-    with open(path, "wb") as fp:
+    if content_hash != LIBSODIUM_HASH:
+        raise ValueError("Hash mismatch for downloaded libsodium")
+
+    with open(tarball_path, "wb") as fp:
         fp.write(content)
 
+    curdir = os.getcwd()
+    try:
+        os.chdir(os.path.expanduser("~/"))
 
-@task(aliases=["install-nacl"])
-def install_nacl(library):
-    def _install_libsodium():
-        tarball_path = os.path.expanduser("~/libsodium-0.2.tar.gz")
+        # Unpack the tarball
+        run("tar xf libsodium-{}.tar.gz".format(LIBSODIUM_VERSION))
 
-        # Download libsodium and verify it's hash
-        download(
-            "http://download.dnscrypt.org/libsodium/releases/libsodium-0.2.tar.gz",
-            "e99a6b69adc080a5acf6b8a49fdc74b61d6f3579b590e85c93446a8325dde100",
-            tarball_path,
+        # Configure and install the library
+        os.chdir(os.path.expanduser(
+                    "~/libsodium-{}/".format(LIBSODIUM_VERSION),
+                ))
+        run("./configure --disable-debug --disable-dependency-tracking",
+            hide="out",
         )
-
-        curdir = os.getcwd()
-        try:
-            os.chdir(os.path.expanduser("~/"))
-
-            # Unpack the tarball
-            run("tar xf libsodium-0.2.tar.gz")
-
-            # Configure and install the library
-            os.chdir(os.path.expanduser("~/libsodium-0.2/"))
-            run("./configure --disable-debug --disable-dependency-tracking", hide="out")
-            run("make", hide="out")
-            run("sudo make install", hide="out")
-        finally:
-            os.chdir(curdir)
-
-    def _install_nacl():
-        tarball_path = os.path.expanduser("~/nacl-20110221.tar.bz2")
-
-        # Download libnacl and verify it's hash
-        download(
-            "http://hyperelliptic.org/nacl/nacl-20110221.tar.bz2",
-            "4f277f89735c8b0b8a6bbd043b3efb3fa1cc68a9a5da6a076507d067fc3b3bf8",
-            tarball_path,
-        )
-
-        curdir = os.getcwd()
-        try:
-            os.chdir(os.path.expanduser("~/"))
-
-            # Unpack the tarball
-            run("tar xf nacl-20110221.tar.bz2", hide="out")
-
-            # Configure and install the library
-            os.chdir(os.path.expanduser("~/nacl-20110221/"))
-            run("sudo ./do", hide="out")
-        finally:
-            os.chdir(curdir)
-
-    libraries = {
-        "libsodium": _install_libsodium,
-        "nacl": _install_nacl,
-    }
-
-    # Install the library
-    libraries[library]()
+        run("make", hide="out")
+        run("sudo make install", hide="out")
+    finally:
+        os.chdir(curdir)
 
 
-@task
-def install(dev=False):
+@task(aliases=["install.requirements"])
+def install_requirements(dev=False):
     if dev:
         # Install once to get the tests extra
         run("pip install file://$PWD#egg=pynacl[tests]", hide="out")


### PR DESCRIPTION
The reference implementation of NaCl hasn't seen a release in a long time and libsodium has several additions we require.
