### PR TITLE
Enable running tests from setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
 from setuptools import setup
+from setuptools.command.test import test as TestCommand
+import sys
 
 __about__ = {}
 
@@ -15,6 +17,18 @@ except ImportError:
 else:
     # building bdist - cffi is here!
     ext_modules = [nacl.nacl.ffi.verifier.get_extension()]
+
+
+class PyTest(TestCommand):
+    def finalize_options(self):
+        TestCommand.finalize_options(self)
+        self.test_args = []
+        self.test_suite = True
+
+    def run_tests(self):
+        import pytest
+        errno = pytest.main(self.test_args)
+        sys.exit(errno)
 
 
 setup(
@@ -45,4 +59,5 @@ setup(
     ext_modules=ext_modules,
 
     zip_safe=False,
+    cmdclass = {'test': PyTest},
 )


### PR DESCRIPTION
Unfortunately, this only works if cffi is already installed.
