### PR TITLE
Enable installation of PyNaCl without a system isntalled libsodium

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 __pycache__/
 *.py[co]
 *.so
+_cffi__*.c
 
 # Packages
 *.egg

--- a/setup.py
+++ b/setup.py
@@ -45,6 +45,7 @@ setup(
     ],
     extras_require={
         "tests": ["pytest"],
+        "sodium": ["sodium>=0.4.3"],
     },
     tests_require=["pytest"],
 


### PR DESCRIPTION
Enable using https://pypi.python.org/pypi/sodium as the backing library instead of relying on a system installed libsodium.

To install PyNaCl using the python packaged sodium as the backing library simply:

``` bash
$ pip install PyNaCl[sodium]
```
