### PR TITLE
Call ffi.cdef() for header files in predictable order

### DIFF
--- a/src/nacl/_lib/__init__.py
+++ b/src/nacl/_lib/__init__.py
@@ -36,8 +36,10 @@ HEADERS = glob.glob(
 ffi = FFI()
 
 
-# Add all of our header files
-for header in HEADERS:
+# Add all of our header files, but sort first for consistency of the
+# hash that CFFI generates and uses in the .so filename (the order of
+# glob() results cannot be relied on)
+for header in sorted(HEADERS):
     with open(header, "r") as hfile:
         ffi.cdef(hfile.read())
 


### PR DESCRIPTION
Always call ffi.cdef() with a consistent ordering of the header files.
This avoids problems where CFFI generates different checksums (used in
.so filenames) at compile time and runtime, and tries to load the wrong
.so file.

Fixes issue #53 (https://github.com/pyca/pynacl/issues/53)
