### PR TITLE
Consistent __future__ imports

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+
 import functools
 import glob
 import os

--- a/src/nacl/__init__.py
+++ b/src/nacl/__init__.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
-from __future__ import division
+
+from __future__ import absolute_import, division, print_function
 
 __all__ = [
     "__title__", "__summary__", "__uri__", "__version__", "__author__",

--- a/src/nacl/_cffi_fix.py
+++ b/src/nacl/_cffi_fix.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+
 import imp
 import os.path
 import sys

--- a/src/nacl/c/__init__.py
+++ b/src/nacl/c/__init__.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from __future__ import absolute_import, division, print_function
 
 from nacl.c.crypto_box import (

--- a/src/nacl/c/crypto_box.py
+++ b/src/nacl/c/crypto_box.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from __future__ import absolute_import, division, print_function
 
 from nacl._lib import lib

--- a/src/nacl/c/crypto_hash.py
+++ b/src/nacl/c/crypto_hash.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from __future__ import absolute_import, division, print_function
 
 from nacl._lib import lib

--- a/src/nacl/c/crypto_scalarmult.py
+++ b/src/nacl/c/crypto_scalarmult.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from __future__ import absolute_import, division, print_function
 
 from nacl._lib import lib

--- a/src/nacl/c/crypto_secretbox.py
+++ b/src/nacl/c/crypto_secretbox.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from __future__ import absolute_import, division, print_function
 
 from nacl._lib import lib

--- a/src/nacl/c/crypto_sign.py
+++ b/src/nacl/c/crypto_sign.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from __future__ import absolute_import, division, print_function
 
 from nacl._lib import lib

--- a/src/nacl/c/randombytes.py
+++ b/src/nacl/c/randombytes.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from __future__ import absolute_import, division, print_function
 
 from nacl._lib import lib

--- a/src/nacl/encoding.py
+++ b/src/nacl/encoding.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+
 import base64
 import binascii
 

--- a/src/nacl/exceptions.py
+++ b/src/nacl/exceptions.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
-from __future__ import division
+
+from __future__ import absolute_import, division, print_function
 
 
 class CryptoError(Exception):

--- a/src/nacl/hash.py
+++ b/src/nacl/hash.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
-from __future__ import division
+
+from __future__ import absolute_import, division, print_function
 
 import nacl.c
 import nacl.encoding

--- a/src/nacl/public.py
+++ b/src/nacl/public.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
-from __future__ import division
+
+from __future__ import absolute_import, division, print_function
 
 import nacl.c
 import nacl.c.crypto_box

--- a/src/nacl/secret.py
+++ b/src/nacl/secret.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
-from __future__ import division
+
+from __future__ import absolute_import, division, print_function
 
 import nacl.c
 

--- a/src/nacl/signing.py
+++ b/src/nacl/signing.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
-from __future__ import division
+
+from __future__ import absolute_import, division, print_function
 
 import six
 

--- a/src/nacl/utils.py
+++ b/src/nacl/utils.py
@@ -11,8 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import absolute_import
-from __future__ import division
+
+from __future__ import absolute_import, division, print_function
 
 import six
 

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+
 import binascii
 import pytest
 

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+
 import pytest
 
 import nacl.encoding

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+
 import pytest
 
 import nacl.hash

--- a/tests/test_raw.py
+++ b/tests/test_raw.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from __future__ import absolute_import, division, print_function
+
 from binascii import hexlify, unhexlify
 from nacl import c
 import hashlib

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+
 import binascii
 import pytest
 

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -11,7 +11,8 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from __future__ import division
+
+from __future__ import absolute_import, division, print_function
 
 import binascii
 import codecs

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,6 +11,9 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+
 import nacl.utils
 
 


### PR DESCRIPTION
This PR cleans up the varied `__future__` imports and brings a consistent structure to the license and `__future__` imports that is more in line with what `cryptography` requires. 
