### PR TITLE
Make use of flake8-import-order to ensure some additional consistency

### DIFF
--- a/src/nacl/c/__init__.py
+++ b/src/nacl/c/__init__.py
@@ -15,28 +15,29 @@
 from __future__ import absolute_import, division, print_function
 
 from nacl.c.crypto_box import (
-    crypto_box_SECRETKEYBYTES, crypto_box_PUBLICKEYBYTES,
-    crypto_box_NONCEBYTES, crypto_box_ZEROBYTES, crypto_box_BOXZEROBYTES,
-    crypto_box_BEFORENMBYTES, crypto_box_keypair, crypto_box, crypto_box_open,
-    crypto_box_beforenm, crypto_box_afternm, crypto_box_open_afternm,
+    crypto_box, crypto_box_BEFORENMBYTES, crypto_box_BOXZEROBYTES,
+    crypto_box_NONCEBYTES, crypto_box_PUBLICKEYBYTES,
+    crypto_box_SECRETKEYBYTES, crypto_box_ZEROBYTES, crypto_box_afternm,
+    crypto_box_beforenm, crypto_box_keypair, crypto_box_open,
+    crypto_box_open_afternm,
 )
 from nacl.c.crypto_hash import (
-    crypto_hash_BYTES, crypto_hash_sha256_BYTES, crypto_hash_sha512_BYTES,
-    crypto_hash, crypto_hash_sha256, crypto_hash_sha512,
+    crypto_hash, crypto_hash_BYTES, crypto_hash_sha256,
+    crypto_hash_sha256_BYTES, crypto_hash_sha512, crypto_hash_sha512_BYTES,
 )
 from nacl.c.crypto_scalarmult import (
-    crypto_scalarmult_BYTES, crypto_scalarmult_SCALARBYTES,
-    crypto_scalarmult, crypto_scalarmult_base,
+    crypto_scalarmult, crypto_scalarmult_BYTES, crypto_scalarmult_SCALARBYTES,
+    crypto_scalarmult_base
 )
 from nacl.c.crypto_secretbox import (
-    crypto_secretbox_KEYBYTES, crypto_secretbox_NONCEBYTES,
-    crypto_secretbox_ZEROBYTES, crypto_secretbox_BOXZEROBYTES,
-    crypto_secretbox, crypto_secretbox_open,
+    crypto_secretbox, crypto_secretbox_BOXZEROBYTES, crypto_secretbox_KEYBYTES,
+    crypto_secretbox_NONCEBYTES, crypto_secretbox_ZEROBYTES,
+    crypto_secretbox_open
 )
 from nacl.c.crypto_sign import (
-    crypto_sign_BYTES, crypto_sign_SEEDBYTES, crypto_sign_PUBLICKEYBYTES,
-    crypto_sign_SECRETKEYBYTES, crypto_sign_keypair, crypto_sign_seed_keypair,
-    crypto_sign, crypto_sign_open,
+    crypto_sign, crypto_sign_BYTES, crypto_sign_PUBLICKEYBYTES,
+    crypto_sign_SECRETKEYBYTES, crypto_sign_SEEDBYTES, crypto_sign_keypair,
+    crypto_sign_open, crypto_sign_seed_keypair,
 )
 from nacl.c.randombytes import randombytes
 from nacl.c.sodium_core import sodium_init

--- a/src/nacl/public.py
+++ b/src/nacl/public.py
@@ -14,10 +14,9 @@
 
 from __future__ import absolute_import, division, print_function
 
+from nacl import encoding
 import nacl.c
 import nacl.c.crypto_box
-
-from nacl import encoding
 from nacl.utils import EncryptedMessage, StringFixer, random
 
 

--- a/src/nacl/secret.py
+++ b/src/nacl/secret.py
@@ -14,10 +14,9 @@
 
 from __future__ import absolute_import, division, print_function
 
+from nacl import encoding
 import nacl.c
-
-from . import encoding
-from .utils import EncryptedMessage, StringFixer
+from nacl.utils import EncryptedMessage, StringFixer
 
 
 class SecretBox(encoding.Encodable, StringFixer, object):

--- a/src/nacl/signing.py
+++ b/src/nacl/signing.py
@@ -16,10 +16,9 @@ from __future__ import absolute_import, division, print_function
 
 import six
 
+from nacl import encoding
 import nacl.c
-
-from . import encoding
-from .utils import StringFixer, random
+from nacl.utils import StringFixer, random
 
 
 class SignedMessage(six.binary_type):

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -15,11 +15,12 @@
 from __future__ import absolute_import, division, print_function
 
 import binascii
+
 import pytest
 
 from nacl.encoding import HexEncoder
-from nacl.public import PrivateKey, PublicKey, Box
 from nacl.exceptions import CryptoError
+from nacl.public import Box, PrivateKey, PublicKey
 
 
 VECTORS = [

--- a/tests/test_hash.py
+++ b/tests/test_hash.py
@@ -16,8 +16,8 @@ from __future__ import absolute_import, division, print_function
 
 import pytest
 
-import nacl.hash
 import nacl.encoding
+import nacl.hash
 
 
 @pytest.mark.parametrize(("inp", "expected"), [

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -15,6 +15,7 @@
 from __future__ import absolute_import, division, print_function
 
 import binascii
+
 import pytest
 
 from nacl.encoding import HexEncoder

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -20,9 +20,9 @@ import os
 
 import pytest
 
-import nacl.signing
 import nacl.encoding
 import nacl.exceptions
+import nacl.signing
 
 
 def ed25519_known_answers():

--- a/tox.ini
+++ b/tox.ini
@@ -25,11 +25,13 @@ commands =
 [testenv:meta]
 deps =
     flake8
+    flake8-import-order
     check-manifest
 commands =
     flake8 .
     check-manifest . --ignore .travis.yml
 
 [flake8]
-select = E,W,F
+select = E,W,F,I
 exclude = .tox,*.egg
+application-import-names = nacl


### PR DESCRIPTION
Also fixes existing violators :-)

I'm not wild about the ordering of::

```
from nacl import signing
import nacl.c
from nacl.exceptions import SomeException
```

But that's fine, a solution might be to remove the `import nacl.c` style.
