### PR TITLE
Use '.' instead of '=' in URLSafeBase64Encoder.

### DIFF
--- a/src/nacl/encoding.py
+++ b/src/nacl/encoding.py
@@ -77,11 +77,11 @@ class URLSafeBase64Encoder(object):
 
     @staticmethod
     def encode(data):
-        return base64.urlsafe_b64encode(data)
+        return base64.urlsafe_b64encode(data).replace('=', '.')
 
     @staticmethod
     def decode(data):
-        return base64.urlsafe_b64decode(data)
+        return base64.urlsafe_b64decode(data.replace('.', '='))
 
 
 class Encodable(object):

--- a/src/nacl/encoding.py
+++ b/src/nacl/encoding.py
@@ -77,11 +77,11 @@ class URLSafeBase64Encoder(object):
 
     @staticmethod
     def encode(data):
-        return base64.urlsafe_b64encode(data).replace('=', '.')
+        return base64.urlsafe_b64encode(data).replace(b'=', b'.')
 
     @staticmethod
     def decode(data):
-        return base64.urlsafe_b64decode(data.replace('.', '='))
+        return base64.urlsafe_b64decode(data.replace(b'.', b'='))
 
 
 class Encodable(object):

--- a/tests/test_encoding.py
+++ b/tests/test_encoding.py
@@ -57,7 +57,7 @@ VECTORS = [
     (
         nacl.encoding.URLSafeBase64Encoder,
         (b"MTExMTExMTExMTExMTExMTExMTExMTEx_FXin-ZFktcORk09eIOPan0gdtTwGjHAiFV"
-         b"rEgIcZPpPSBPcDg7XQQcLLp8Bv-TQc_FQ0w6qnbP3XA8="),
+         b"rEgIcZPpPSBPcDg7XQQcLLp8Bv-TQc_FQ0w6qnbP3XA8."),
     ),
 ]
 


### PR DESCRIPTION
According to [RFC 3986](http://www.ietf.org/rfc/rfc3986.txt) section 2.3, the equal sign (=) is not an
unreserved character in URLs:

> Characters that are allowed in a URI but do not have a reserved purpose are called unreserved.  These include uppercase and lowercase letters, decimal digits, hyphen, period, underscore, and tilde.

Since the tilde is common used to represent home directories, I chose to use the period (.) for padding instead.