### PR TITLE
add type-checks to constructors

### DIFF
--- a/src/nacl/public.py
+++ b/src/nacl/public.py
@@ -25,6 +25,8 @@ class PublicKey(encoding.Encodable, StringFixer, object):
 
     def __init__(self, public_key, encoder=encoding.RawEncoder):
         self._public_key = encoder.decode(public_key)
+        if not isinstance(self._public_key, bytes):
+            raise TypeError("PublicKey must be created from 32 bytes")
 
         if len(self._public_key) != self.SIZE:
             raise ValueError("The public key must be exactly %s bytes long" %
@@ -41,6 +43,8 @@ class PrivateKey(encoding.Encodable, StringFixer, object):
     def __init__(self, private_key, encoder=encoding.RawEncoder):
         # Decode the secret_key
         private_key = encoder.decode(private_key)
+        if not isinstance(private_key, bytes):
+            raise TypeError("PrivateKey must be created from a 32 byte seed")
 
         # Verify that our seed is the proper size
         if len(private_key) != self.SIZE:
@@ -66,6 +70,10 @@ class Box(encoding.Encodable, StringFixer, object):
 
     def __init__(self, private_key, public_key):
         if private_key and public_key:
+            if ((not isinstance(private_key, PrivateKey)
+                 or not isinstance(public_key, PublicKey))):
+                raise TypeError("Box must be created from "
+                                "a PrivateKey and a PublicKey")
             self._shared_key = nacl.c.crypto_box_beforenm(
                 public_key.encode(encoder=encoding.RawEncoder),
                 private_key.encode(encoder=encoding.RawEncoder),

--- a/src/nacl/secret.py
+++ b/src/nacl/secret.py
@@ -26,6 +26,8 @@ class SecretBox(encoding.Encodable, StringFixer, object):
 
     def __init__(self, key, encoder=encoding.RawEncoder):
         key = encoder.decode(key)
+        if not isinstance(key, bytes):
+            raise TypeError("SecretBox must be created from 32 bytes")
 
         if len(key) != self.KEY_SIZE:
             raise ValueError(

--- a/src/nacl/signing.py
+++ b/src/nacl/signing.py
@@ -61,6 +61,8 @@ class VerifyKey(encoding.Encodable, StringFixer, object):
     def __init__(self, key, encoder=encoding.RawEncoder):
         # Decode the key
         key = encoder.decode(key)
+        if not isinstance(key, bytes):
+            raise TypeError("VerifyKey must be created from 32 bytes")
 
         if len(key) != nacl.c.crypto_sign_PUBLICKEYBYTES:
             raise ValueError(
@@ -120,6 +122,8 @@ class SigningKey(encoding.Encodable, StringFixer, object):
     def __init__(self, seed, encoder=encoding.RawEncoder):
         # Decode the seed
         seed = encoder.decode(seed)
+        if not isinstance(seed, bytes):
+            raise TypeError("SigningKey must be created from a 32 byte seed")
 
         # Verify that our seed is the proper size
         if len(seed) != nacl.c.crypto_sign_SEEDBYTES:

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -24,7 +24,7 @@ from nacl.public import Box, PrivateKey, PublicKey
 
 
 VECTORS = [
-    # skalice, pkalice, skbob, pkbob, nonce, plaintext, ciphertext
+    # privalice, pubalice, privbob, pubbob, nonce, plaintext, ciphertext
     (
         b"77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a",
         b"8520f0098930a754748b7ddcb43ef75a0dbf3a0d26381af4eba4a98eaa9b4e6a",
@@ -49,57 +49,57 @@ def test_generate_private_key():
 
 
 def test_box_creation():
-    pk = PublicKey(
+    pub = PublicKey(
         b"ec2bee2d5be613ca82e377c96a0bf2220d823ce980cdff6279473edc52862798",
         encoder=HexEncoder,
     )
-    sk = PrivateKey(
+    priv = PrivateKey(
         b"5c2bee2d5be613ca82e377c96a0bf2220d823ce980cdff6279473edc52862798",
         encoder=HexEncoder,
     )
-    Box(sk, pk)
+    Box(priv, pub)
 
 
 def test_box_decode():
-    pk = PublicKey(
+    pub = PublicKey(
         b"ec2bee2d5be613ca82e377c96a0bf2220d823ce980cdff6279473edc52862798",
         encoder=HexEncoder,
     )
-    sk = PrivateKey(
+    priv = PrivateKey(
         b"5c2bee2d5be613ca82e377c96a0bf2220d823ce980cdff6279473edc52862798",
         encoder=HexEncoder,
     )
-    b1 = Box(sk, pk)
+    b1 = Box(priv, pub)
     b2 = Box.decode(b1._shared_key)
     assert b1._shared_key == b2._shared_key
 
 
 def test_box_bytes():
-    pk = PublicKey(
+    pub = PublicKey(
         b"ec2bee2d5be613ca82e377c96a0bf2220d823ce980cdff6279473edc52862798",
         encoder=HexEncoder,
     )
-    sk = PrivateKey(
+    priv = PrivateKey(
         b"5c2bee2d5be613ca82e377c96a0bf2220d823ce980cdff6279473edc52862798",
         encoder=HexEncoder,
     )
-    b = Box(sk, pk)
+    b = Box(priv, pub)
     assert bytes(b) == b._shared_key
 
 
 @pytest.mark.parametrize(
     (
-        "skalice", "pkalice", "skbob", "pkbob", "nonce", "plaintext",
+        "privalice", "pubalice", "privbob", "pubbob", "nonce", "plaintext",
         "ciphertext",
     ),
     VECTORS,
 )
 def test_box_encryption(
-        skalice, pkalice, skbob, pkbob, nonce, plaintext, ciphertext):
-    pkalice = PublicKey(pkalice, encoder=HexEncoder)
-    skbob = PrivateKey(skbob, encoder=HexEncoder)
+        privalice, pubalice, privbob, pubbob, nonce, plaintext, ciphertext):
+    pubalice = PublicKey(pubalice, encoder=HexEncoder)
+    privbob = PrivateKey(privbob, encoder=HexEncoder)
 
-    box = Box(skbob, pkalice)
+    box = Box(privbob, pubalice)
     encrypted = box.encrypt(
         binascii.unhexlify(plaintext),
         binascii.unhexlify(nonce),
@@ -117,17 +117,17 @@ def test_box_encryption(
 
 @pytest.mark.parametrize(
     (
-        "skalice", "pkalice", "skbob", "pkbob", "nonce", "plaintext",
+        "privalice", "pubalice", "privbob", "pubbob", "nonce", "plaintext",
         "ciphertext",
     ),
     VECTORS,
 )
 def test_box_decryption(
-        skalice, pkalice, skbob, pkbob, nonce, plaintext, ciphertext):
-    pkbob = PublicKey(pkbob, encoder=HexEncoder)
-    skalice = PrivateKey(skalice, encoder=HexEncoder)
+        privalice, pubalice, privbob, pubbob, nonce, plaintext, ciphertext):
+    pubbob = PublicKey(pubbob, encoder=HexEncoder)
+    privalice = PrivateKey(privalice, encoder=HexEncoder)
 
-    box = Box(skalice, pkbob)
+    box = Box(privalice, pubbob)
 
     nonce = binascii.unhexlify(nonce)
     decrypted = binascii.hexlify(
@@ -139,17 +139,17 @@ def test_box_decryption(
 
 @pytest.mark.parametrize(
     (
-        "skalice", "pkalice", "skbob", "pkbob", "nonce", "plaintext",
+        "privalice", "pubalice", "privbob", "pubbob", "nonce", "plaintext",
         "ciphertext",
     ),
     VECTORS,
 )
 def test_box_decryption_combined(
-        skalice, pkalice, skbob, pkbob, nonce, plaintext, ciphertext):
-    pkbob = PublicKey(pkbob, encoder=HexEncoder)
-    skalice = PrivateKey(skalice, encoder=HexEncoder)
+        privalice, pubalice, privbob, pubbob, nonce, plaintext, ciphertext):
+    pubbob = PublicKey(pubbob, encoder=HexEncoder)
+    privalice = PrivateKey(privalice, encoder=HexEncoder)
 
-    box = Box(skalice, pkbob)
+    box = Box(privalice, pubbob)
 
     combined = binascii.hexlify(
         binascii.unhexlify(nonce) + binascii.unhexlify(ciphertext),
@@ -161,19 +161,19 @@ def test_box_decryption_combined(
 
 @pytest.mark.parametrize(
     (
-        "skalice", "pkalice", "skbob", "pkbob", "nonce", "plaintext",
+        "privalice", "pubalice", "privbob", "pubbob", "nonce", "plaintext",
         "ciphertext",
     ),
     VECTORS,
 )
 def test_box_failed_decryption(
-        skalice, pkalice, skbob, pkbob, nonce, plaintext, ciphertext):
-    pkbob = PublicKey(pkbob, encoder=HexEncoder)
-    skbob = PrivateKey(skbob, encoder=HexEncoder)
+        privalice, pubalice, privbob, pubbob, nonce, plaintext, ciphertext):
+    pubbob = PublicKey(pubbob, encoder=HexEncoder)
+    privbob = PrivateKey(privbob, encoder=HexEncoder)
 
-    # this cannot decrypt the ciphertext!
-    # the ciphertext must be decrypted by (skalice, pkbob) or (skbob, pkalice)
-    box = Box(skbob, pkbob)
+    # this cannot decrypt the ciphertext! the ciphertext must be decrypted by
+    # (privalice, pubbob) or (privbob, pubalice)
+    box = Box(privbob, pubbob)
 
     with pytest.raises(CryptoError):
         box.decrypt(ciphertext, binascii.unhexlify(nonce), encoder=HexEncoder)
@@ -185,15 +185,15 @@ def test_box_wrong_length():
     with pytest.raises(ValueError):
         PrivateKey(b"")
 
-    pk = PublicKey(
+    pub = PublicKey(
         b"ec2bee2d5be613ca82e377c96a0bf2220d823ce980cdff6279473edc52862798",
         encoder=HexEncoder,
     )
-    sk = PrivateKey(
+    priv = PrivateKey(
         b"5c2bee2d5be613ca82e377c96a0bf2220d823ce980cdff6279473edc52862798",
         encoder=HexEncoder,
     )
-    b = Box(sk, pk)
+    b = Box(priv, pub)
     with pytest.raises(ValueError):
         b.encrypt(b"", b"")
     with pytest.raises(ValueError):
@@ -207,27 +207,27 @@ def check_type_error(expected, f, *args):
 
 
 def test_wrong_types():
-    sk = PrivateKey.generate()
+    priv = PrivateKey.generate()
 
     check_type_error("PrivateKey must be created from a 32 byte seed",
                      PrivateKey, 12)
     check_type_error("PrivateKey must be created from a 32 byte seed",
-                     PrivateKey, sk)
+                     PrivateKey, priv)
     check_type_error("PrivateKey must be created from a 32 byte seed",
-                     PrivateKey, sk.public_key)
+                     PrivateKey, priv.public_key)
 
     check_type_error("PublicKey must be created from 32 bytes",
                      PublicKey, 13)
     check_type_error("PublicKey must be created from 32 bytes",
-                     PublicKey, sk)
+                     PublicKey, priv)
     check_type_error("PublicKey must be created from 32 bytes",
-                     PublicKey, sk.public_key)
+                     PublicKey, priv.public_key)
 
     check_type_error("Box must be created from a PrivateKey and a PublicKey",
-                     Box, sk, "not a public key")
+                     Box, priv, "not a public key")
     check_type_error("Box must be created from a PrivateKey and a PublicKey",
-                     Box, sk.encode(), sk.public_key.encode())
+                     Box, priv.encode(), priv.public_key.encode())
     check_type_error("Box must be created from a PrivateKey and a PublicKey",
-                     Box, sk, sk.public_key.encode())
+                     Box, priv, priv.public_key.encode())
     check_type_error("Box must be created from a PrivateKey and a PublicKey",
-                     Box, sk.encode(), sk.public_key)
+                     Box, priv.encode(), priv.public_key)

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -109,3 +109,18 @@ def test_secret_box_wrong_lengths():
         box.encrypt(b"", b"")
     with pytest.raises(ValueError):
         box.decrypt(b"", b"")
+
+
+def check_type_error(expected, f, *args):
+    with pytest.raises(TypeError) as e:
+        f(*args)
+    assert expected in str(e)
+
+
+def test_wrong_types():
+    box = SecretBox(b"11" * 32, encoder=HexEncoder)
+
+    check_type_error("SecretBox must be created from 32 bytes",
+                     SecretBox, 12)
+    check_type_error("SecretBox must be created from 32 bytes",
+                     SecretBox, box)

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -131,3 +131,27 @@ class TestVerifyKey:
         with pytest.raises(BadSignatureError):
             forged = SignedMessage(signature + message)
             skey.verify_key.verify(forged)
+
+
+def check_type_error(expected, f, *args):
+    with pytest.raises(TypeError) as e:
+        f(*args)
+    assert expected in str(e)
+
+
+def test_wrong_types():
+    sk = SigningKey.generate()
+
+    check_type_error("SigningKey must be created from a 32 byte seed",
+                     SigningKey, 12)
+    check_type_error("SigningKey must be created from a 32 byte seed",
+                     SigningKey, sk)
+    check_type_error("SigningKey must be created from a 32 byte seed",
+                     SigningKey, sk.verify_key)
+
+    check_type_error("VerifyKey must be created from 32 bytes",
+                     VerifyKey, 13)
+    check_type_error("VerifyKey must be created from 32 bytes",
+                     VerifyKey, sk)
+    check_type_error("VerifyKey must be created from 32 bytes",
+                     VerifyKey, sk.verify_key)

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -20,9 +20,10 @@ import os
 
 import pytest
 
-import nacl.encoding
-import nacl.exceptions
-import nacl.signing
+from nacl.c import crypto_sign_PUBLICKEYBYTES, crypto_sign_SEEDBYTES
+from nacl.encoding import HexEncoder
+from nacl.exceptions import BadSignatureError
+from nacl.signing import SignedMessage, SigningKey, VerifyKey
 
 
 def ed25519_known_answers():
@@ -48,21 +49,21 @@ def ed25519_known_answers():
 
 class TestSigningKey:
     def test_initialize_with_generate(self):
-        nacl.signing.SigningKey.generate()
+        SigningKey.generate()
 
     def test_wrong_length(self):
         with pytest.raises(ValueError):
-            nacl.signing.SigningKey(b"")
+            SigningKey(b"")
 
     def test_bytes(self):
-        k = nacl.signing.SigningKey(b"\x00" * nacl.c.crypto_sign_SEEDBYTES)
-        assert bytes(k) == b"\x00" * nacl.c.crypto_sign_SEEDBYTES
+        k = SigningKey(b"\x00" * crypto_sign_SEEDBYTES)
+        assert bytes(k) == b"\x00" * crypto_sign_SEEDBYTES
 
     @pytest.mark.parametrize("seed", [
         b"77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a",
     ])
     def test_initialization_with_seed(self, seed):
-        nacl.signing.SigningKey(seed, encoder=nacl.encoding.HexEncoder)
+        SigningKey(seed, encoder=HexEncoder)
 
     @pytest.mark.parametrize(
         ("seed", "message", "signature", "expected"),
@@ -72,13 +73,13 @@ class TestSigningKey:
         ],
     )
     def test_message_signing(self, seed, message, signature, expected):
-        signing_key = nacl.signing.SigningKey(
+        signing_key = SigningKey(
             seed,
-            encoder=nacl.encoding.HexEncoder,
+            encoder=HexEncoder,
         )
         signed = signing_key.sign(
             binascii.unhexlify(message),
-            encoder=nacl.encoding.HexEncoder,
+            encoder=HexEncoder,
         )
 
         assert signed == expected
@@ -89,11 +90,11 @@ class TestSigningKey:
 class TestVerifyKey:
     def test_wrong_length(self):
         with pytest.raises(ValueError):
-            nacl.signing.VerifyKey(b"")
+            VerifyKey(b"")
 
     def test_bytes(self):
-        k = nacl.signing.VerifyKey(b"\x00" * nacl.c.crypto_sign_PUBLICKEYBYTES)
-        assert bytes(k) == b"\x00" * nacl.c.crypto_sign_PUBLICKEYBYTES
+        k = VerifyKey(b"\x00" * crypto_sign_PUBLICKEYBYTES)
+        assert bytes(k) == b"\x00" * crypto_sign_PUBLICKEYBYTES
 
     @pytest.mark.parametrize(
         ("public_key", "signed", "message", "signature"),
@@ -104,29 +105,29 @@ class TestVerifyKey:
     )
     def test_valid_signed_message(
             self, public_key, signed, message, signature):
-        key = nacl.signing.VerifyKey(
+        key = VerifyKey(
             public_key,
-            encoder=nacl.encoding.HexEncoder,
+            encoder=HexEncoder,
         )
 
         assert binascii.hexlify(
-            key.verify(signed, encoder=nacl.encoding.HexEncoder),
+            key.verify(signed, encoder=HexEncoder),
         ) == message
         assert binascii.hexlify(
-            key.verify(message, signature, encoder=nacl.encoding.HexEncoder),
+            key.verify(message, signature, encoder=HexEncoder),
         ) == message
 
     def test_invalid_signed_message(self):
-        skey = nacl.signing.SigningKey.generate()
+        skey = SigningKey.generate()
         smessage = skey.sign(b"A Test Message!")
         signature, message = smessage.signature, b"A Forged Test Message!"
 
         # Small sanity check
         assert skey.verify_key.verify(smessage)
 
-        with pytest.raises(nacl.exceptions.BadSignatureError):
+        with pytest.raises(BadSignatureError):
             skey.verify_key.verify(message, signature)
 
-        with pytest.raises(nacl.exceptions.BadSignatureError):
-            forged = nacl.signing.SignedMessage(signature + message)
+        with pytest.raises(BadSignatureError):
+            forged = SignedMessage(signature + message)
             skey.verify_key.verify(forged)


### PR DESCRIPTION
This also cleans up the imports in test_signing.py to match the convention used by the other test cases, and changes test_box.py to avoid the "pk"-vs-"sk" confusion by using "priv" and "pub".