### PR TITLE
Fix TEST_NAME constant in scalarmult8.c

### DIFF
--- a/src/libsodium/test/default/scalarmult8.c
+++ b/src/libsodium/test/default/scalarmult8.c
@@ -1,6 +1,6 @@
 #include <stdio.h>
 #include <string.h>
-#define TEST_NAME "scalarmult7"
+#define TEST_NAME "scalarmult8"
 #include "cmptest.h"
 
 unsigned char p1[32] = {


### PR DESCRIPTION
The test fails otherwise and hence the install.
