### PR TITLE
Insert 'src' folder at the start of the pythonpath rather than the end

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ def here(*paths):
 sodium = functools.partial(here, "src/libsodium/src/libsodium")
 
 
-sys.path.append(here("src"))
+sys.path.insert(0, here("src"))
 
 
 import nacl


### PR DESCRIPTION
Otherwise the version of nacl to install might be overridden by an existing installation when setup is called with "version=nacl.**version**".
