### PR TITLE
Apply some of the techniques from https://caremad.io/2014/11/distribu… … …ting-a-cffi-project/

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,12 @@ import os.path
 import subprocess
 import sys
 
+from distutils.command.build import build
 from distutils.command.build_clib import build_clib as _build_clib
 from distutils.command.build_ext import build_ext as _build_ext
 
 from setuptools import Distribution, setup
 
-from distutils.command.build import build
 from setuptools.command.install import install
 
 


### PR DESCRIPTION
In particular make sure "nacl._lib" is imported after setup has installed the setup_requires. Otherwise trying to pip install pynacl on a fresh system which doesn't have cffi installed will silently fail because it won't have built the cffi extension module.
