### PR TITLE
disable flake8 on the two out-of-order "import nacl" lines

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -20,7 +20,7 @@ except ImportError:
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 sys.path.insert(0, os.path.abspath("../src"))
 
-import nacl
+import nacl # flake8: noqa
 
 # -- General configuration ----------------------------------------------------
 

--- a/setup.py
+++ b/setup.py
@@ -46,7 +46,7 @@ sodium = functools.partial(here, "src/libsodium/src/libsodium")
 sys.path.insert(0, here("src"))
 
 
-import nacl
+import nacl # flake8: noqa
 
 
 def which(name, flags=os.X_OK):  # Taken from twisted


### PR DESCRIPTION
These imports must necessarily appear "out of order" (in violation of
flake8's rules), so disable flake8 checking for them without reducing
coverage of anything else.