### PR TITLE
improve coverage: many functions cannot return an error

### DIFF
--- a/src/nacl/bindings/crypto_box.py
+++ b/src/nacl/bindings/crypto_box.py
@@ -38,8 +38,8 @@ def crypto_box_keypair():
     pk = lib.ffi.new("unsigned char[]", crypto_box_PUBLICKEYBYTES)
     sk = lib.ffi.new("unsigned char[]", crypto_box_SECRETKEYBYTES)
 
-    if lib.crypto_box_keypair(pk, sk) != 0:
-        raise CryptoError("An error occurred trying to generate the keypair")
+    rc = lib.crypto_box_keypair(pk, sk)
+    assert rc == 0
 
     return (
         lib.ffi.buffer(pk, crypto_box_PUBLICKEYBYTES)[:],
@@ -70,8 +70,8 @@ def crypto_box(message, nonce, pk, sk):
     padded = (b"\x00" * crypto_box_ZEROBYTES) + message
     ciphertext = lib.ffi.new("unsigned char[]", len(padded))
 
-    if lib.crypto_box(ciphertext, padded, len(padded), nonce, pk, sk) != 0:
-        raise CryptoError("An error occurred trying to encrypt the message")
+    rc = lib.crypto_box(ciphertext, padded, len(padded), nonce, pk, sk)
+    assert rc == 0
 
     return lib.ffi.buffer(ciphertext, len(padded))[crypto_box_BOXZEROBYTES:]
 
@@ -123,8 +123,8 @@ def crypto_box_beforenm(pk, sk):
 
     k = lib.ffi.new("unsigned char[]", crypto_box_BEFORENMBYTES)
 
-    if lib.crypto_box_beforenm(k, pk, sk) != 0:
-        raise CryptoError("An error occurred computing the shared key.")
+    rc = lib.crypto_box_beforenm(k, pk, sk)
+    assert rc == 0
 
     return lib.ffi.buffer(k, crypto_box_BEFORENMBYTES)[:]
 
@@ -148,8 +148,8 @@ def crypto_box_afternm(message, nonce, k):
     padded = b"\x00" * crypto_box_ZEROBYTES + message
     ciphertext = lib.ffi.new("unsigned char[]", len(padded))
 
-    if lib.crypto_box_afternm(ciphertext, padded, len(padded), nonce, k) != 0:
-        raise CryptoError("An error occurred trying to encrypt the message")
+    rc = lib.crypto_box_afternm(ciphertext, padded, len(padded), nonce, k)
+    assert rc == 0
 
     return lib.ffi.buffer(ciphertext, len(padded))[crypto_box_BOXZEROBYTES:]
 

--- a/src/nacl/bindings/crypto_hash.py
+++ b/src/nacl/bindings/crypto_hash.py
@@ -15,7 +15,6 @@
 from __future__ import absolute_import, division, print_function
 
 from nacl._lib import lib
-from nacl.exceptions import CryptoError
 
 
 # crypto_hash_BYTES = lib.crypto_hash_bytes()
@@ -32,8 +31,8 @@ def crypto_hash(message):
     :rtype: bytes
     """
     digest = lib.ffi.new("unsigned char[]", crypto_hash_BYTES)
-    if lib.crypto_hash(digest, message, len(message)) != 0:
-        raise CryptoError("Hashing failed")
+    rc = lib.crypto_hash(digest, message, len(message))
+    assert rc == 0
     return lib.ffi.buffer(digest, crypto_hash_BYTES)[:]
 
 
@@ -45,8 +44,8 @@ def crypto_hash_sha256(message):
     :rtype: bytes
     """
     digest = lib.ffi.new("unsigned char[]", crypto_hash_sha256_BYTES)
-    if lib.crypto_hash_sha256(digest, message, len(message)) != 0:
-        raise CryptoError("Hashing failed")
+    rc = lib.crypto_hash_sha256(digest, message, len(message))
+    assert rc == 0
     return lib.ffi.buffer(digest, crypto_hash_sha256_BYTES)[:]
 
 
@@ -58,6 +57,6 @@ def crypto_hash_sha512(message):
     :rtype: bytes
     """
     digest = lib.ffi.new("unsigned char[]", crypto_hash_sha512_BYTES)
-    if lib.crypto_hash_sha512(digest, message, len(message)) != 0:
-        raise CryptoError("Hashing failed")
+    rc = lib.crypto_hash_sha512(digest, message, len(message))
+    assert rc == 0
     return lib.ffi.buffer(digest, crypto_hash_sha512_BYTES)[:]

--- a/src/nacl/bindings/crypto_sign.py
+++ b/src/nacl/bindings/crypto_sign.py
@@ -15,7 +15,7 @@
 from __future__ import absolute_import, division, print_function
 
 from nacl._lib import lib
-from nacl.exceptions import BadSignatureError, CryptoError
+from nacl.exceptions import BadSignatureError
 
 
 crypto_sign_BYTES = lib.crypto_sign_bytes()
@@ -34,8 +34,8 @@ def crypto_sign_keypair():
     pk = lib.ffi.new("unsigned char[]", crypto_sign_PUBLICKEYBYTES)
     sk = lib.ffi.new("unsigned char[]", crypto_sign_SECRETKEYBYTES)
 
-    if lib.crypto_sign_keypair(pk, sk) != 0:
-        raise CryptoError("An error occurred while generating keypairs")
+    rc = lib.crypto_sign_keypair(pk, sk)
+    assert rc == 0
 
     return (
         lib.ffi.buffer(pk, crypto_sign_PUBLICKEYBYTES)[:],
@@ -56,8 +56,8 @@ def crypto_sign_seed_keypair(seed):
     pk = lib.ffi.new("unsigned char[]", crypto_sign_PUBLICKEYBYTES)
     sk = lib.ffi.new("unsigned char[]", crypto_sign_SECRETKEYBYTES)
 
-    if lib.crypto_sign_seed_keypair(pk, sk, seed) != 0:
-        raise CryptoError("An error occurred while generating keypairs")
+    rc = lib.crypto_sign_seed_keypair(pk, sk, seed)
+    assert rc == 0
 
     return (
         lib.ffi.buffer(pk, crypto_sign_PUBLICKEYBYTES)[:],
@@ -77,8 +77,8 @@ def crypto_sign(message, sk):
     signed = lib.ffi.new("unsigned char[]", len(message) + crypto_sign_BYTES)
     signed_len = lib.ffi.new("unsigned long long *")
 
-    if lib.crypto_sign(signed, signed_len, message, len(message), sk) != 0:
-        raise CryptoError("Failed to sign the message")
+    rc = lib.crypto_sign(signed, signed_len, message, len(message), sk)
+    assert rc == 0
 
     return lib.ffi.buffer(signed, signed_len[0])[:]
 


### PR DESCRIPTION
libsodium pretends they return a useful result code for consistency, but
the underlying code always returns 0. So these functions can just use
`assert rc == 0` instead of an unreachable `raise CryptoError`.