### PR TITLE
Enable checking keys for equality.

### DIFF
--- a/src/nacl/public.py
+++ b/src/nacl/public.py
@@ -44,6 +44,11 @@ class PublicKey(encoding.Encodable, StringFixer, object):
     def __bytes__(self):
         return self._public_key
 
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return bytes(self) == bytes(other)
+
 
 class PrivateKey(encoding.Encodable, StringFixer, object):
     """
@@ -80,6 +85,11 @@ class PrivateKey(encoding.Encodable, StringFixer, object):
 
     def __bytes__(self):
         return self._private_key
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return bytes(self) == bytes(other)
 
     @classmethod
     def generate(cls):

--- a/src/nacl/signing.py
+++ b/src/nacl/signing.py
@@ -75,6 +75,11 @@ class VerifyKey(encoding.Encodable, StringFixer, object):
     def __bytes__(self):
         return self._key
 
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return bytes(self) == bytes(other)
+
     def verify(self, smessage, signature=None, encoder=encoding.RawEncoder):
         """
         Verifies the signature of a signed message, returning the message
@@ -140,6 +145,11 @@ class SigningKey(encoding.Encodable, StringFixer, object):
 
     def __bytes__(self):
         return self._seed
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return bytes(self) == bytes(other)
 
     @classmethod
     def generate(cls):

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -1,0 +1,40 @@
+# Copyright 2013 Donald Stufft and individual contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import pytest
+
+from nacl.bindings import crypto_box_PUBLICKEYBYTES, crypto_box_SECRETKEYBYTES
+from nacl.public import PublicKey, PrivateKey
+
+class TestPublicKey:
+    def test_eq_returns_True_for_identical_keys(self):
+        k1 = PublicKey(b"\x00" * crypto_box_PUBLICKEYBYTES)
+        k2 = PublicKey(b"\x00" * crypto_box_PUBLICKEYBYTES)
+        assert k1 == k2
+
+    def test_eq_returns_False_for_wrong_type(self):
+        k1 = PublicKey(b"\x00" * crypto_box_PUBLICKEYBYTES)
+        k2 = b"\x00" * crypto_box_PUBLICKEYBYTES
+        assert k1 != k2
+
+class TestPrivateKey:
+    def test_eq_returns_True_for_identical_keys(self):
+        k1 = PrivateKey(b"\x00" * crypto_box_SECRETKEYBYTES)
+        k2 = PrivateKey(b"\x00" * crypto_box_SECRETKEYBYTES)
+        assert k1 == k2
+
+    def test_eq_returns_False_for_wrong_type(self):
+        k1 = PrivateKey(b"\x00" * crypto_box_SECRETKEYBYTES)
+        k2 = b"\x00" * crypto_box_SECRETKEYBYTES
+        assert k1 != k2

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -59,6 +59,16 @@ class TestSigningKey:
         k = SigningKey(b"\x00" * crypto_sign_SEEDBYTES)
         assert bytes(k) == b"\x00" * crypto_sign_SEEDBYTES
 
+    def test_eq_returns_True_for_identical_keys(self):
+        k1 = SigningKey(b"\x00" * crypto_sign_SEEDBYTES)
+        k2 = SigningKey(b"\x00" * crypto_sign_SEEDBYTES)
+        assert k1 == k2
+
+    def test_eq_returns_False_for_wrong_type(self):
+        k1 = SigningKey(b"\x00" * crypto_sign_SEEDBYTES)
+        k2 = b"\x00" * crypto_sign_SEEDBYTES
+        assert k1 != k2
+
     @pytest.mark.parametrize("seed", [
         b"77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a",
     ])
@@ -95,6 +105,16 @@ class TestVerifyKey:
     def test_bytes(self):
         k = VerifyKey(b"\x00" * crypto_sign_PUBLICKEYBYTES)
         assert bytes(k) == b"\x00" * crypto_sign_PUBLICKEYBYTES
+
+    def test_eq_returns_True_for_identical_keys(self):
+        k1 = VerifyKey(b"\x00" * crypto_sign_PUBLICKEYBYTES)
+        k2 = VerifyKey(b"\x00" * crypto_sign_PUBLICKEYBYTES)
+        assert k1 == k2
+
+    def test_eq_returns_False_for_wrong_type(self):
+        k1 = VerifyKey(b"\x00" * crypto_sign_PUBLICKEYBYTES)
+        k2 = b"\x00" * crypto_sign_PUBLICKEYBYTES
+        assert k1 != k2
 
     @pytest.mark.parametrize(
         ("public_key", "signed", "message", "signature"),


### PR DESCRIPTION
I decided to use the `bytes` representation when comparing key objects. However, testing a key object and its own bytes representation for equality should not evaluate to `True`, see the corresponding unit tests.