### PR TITLE
Add a getter for DH shared key

### DIFF
--- a/src/nacl/public.py
+++ b/src/nacl/public.py
@@ -82,29 +82,29 @@ class PrivateKey(encoding.Encodable, StringFixer, object):
         return self._private_key
 
     @classmethod
-    def generate(cls, add_e=''):
+    def generate(cls, ext_e=''):
         """
         Generates a random :class:`~nacl.public.PrivateKey` object
 
-        :param add_e: Additional entropy provided by user. XORed with system
-            entropy. If left empty, uses only nacl.utils.random().
+        :param ext_e: External entropy provided by user. XORed with system
+            entropy. If left empty, only nacl.utils.random() is used.
 
         :rtype: :class:`~nacl.public.PrivateKey`
         """
 
         size = nacl.bindings.crypto_box_SECRETKEYBYTES
 
-        if not add_e:
-            add_e = str(bytearray(size))
+        if not ext_e:
+            ext_e = str(bytearray(size))
 
-        if len(add_e) != size:
+        if len(ext_e) != size:
             raise ValueError(
-                "Additional entropy must be exactly %d bytes long" % size)
+                "External entropy must be exactly %d bytes long" % size)
 
-        sys_e = random(PrivateKey.size)
+        nacl_e = random(PrivateKey.size)
 
-        # XOR nacl.utils.random with add. entropy or with bit string of zeroes.
-        final = ''.join(chr(ord(s) ^ ord(a)) for s, a in zip(sys_e, add_e))
+        # XOR nacl.utils.random with ext. entropy or with bit string of zeroes.
+        final = ''.join(chr(ord(s) ^ ord(a)) for s, a in zip(nacl_e, ext_e))
 
         return cls(final, encoder=encoding.RawEncoder)
 

--- a/src/nacl/public.py
+++ b/src/nacl/public.py
@@ -139,6 +139,9 @@ class Box(encoding.Encodable, StringFixer, object):
 
         return box
 
+    def sharedKey(self):
+        return self._shared_key
+
     def encrypt(self, plaintext, nonce, encoder=encoding.RawEncoder):
         """
         Encrypts the plaintext message using the given `nonce` and returns

--- a/src/nacl/public.py
+++ b/src/nacl/public.py
@@ -96,14 +96,14 @@ class PrivateKey(encoding.Encodable, StringFixer, object):
             raise TypeError("External entropy provided must be bytes")
 
         # If no external entropy is provided, create string of zero-bytes.
-        size = nacl.bindings.crypto_box_SECRETKEYBYTES
         if not ext_e:
-            ext_e = str(bytearray(size))
+            ext_e = str(bytearray(PrivateKey.SIZE))
 
         # Verify that external entropy is the proper size
-        if len(ext_e) != size:
+        if len(ext_e) != PrivateKey.SIZE:
             raise ValueError(
-                "External entropy must be exactly %d bytes long" % size)
+                "External entropy must be exactly %d bytes long"
+                % PrivateKey.SIZE)
 
         nacl_e = random(PrivateKey.size)
 

--- a/src/nacl/public.py
+++ b/src/nacl/public.py
@@ -92,11 +92,15 @@ class PrivateKey(encoding.Encodable, StringFixer, object):
         :rtype: :class:`~nacl.public.PrivateKey`
         """
 
-        size = nacl.bindings.crypto_box_SECRETKEYBYTES
+        if not isinstance(ext_e, bytes):
+            raise TypeError("External entropy provided must be bytes")
 
+        # If no external entropy is provided, create string of zero-bytes.
+        size = nacl.bindings.crypto_box_SECRETKEYBYTES
         if not ext_e:
             ext_e = str(bytearray(size))
 
+        # Verify that external entropy is the proper size
         if len(ext_e) != size:
             raise ValueError(
                 "External entropy must be exactly %d bytes long" % size)

--- a/src/nacl/public.py
+++ b/src/nacl/public.py
@@ -105,7 +105,7 @@ class PrivateKey(encoding.Encodable, StringFixer, object):
                 "External entropy must be exactly %d bytes long"
                 % PrivateKey.SIZE)
 
-        nacl_e = random(PrivateKey.size)
+        nacl_e = random(PrivateKey.SIZE)
 
         # XOR nacl.utils.random with ext. entropy or with bit string of zeroes.
         final = ''.join(chr(ord(s) ^ ord(a)) for s, a in zip(nacl_e, ext_e))


### PR DESCRIPTION
I'm asking you to add a way for developers to also access the DH shared secret.

There might be other use cases too, but at least in [the one](https://github.com/maqp/tfc-cev) I'm working on where all key-exchange related data received needs to be manually typed on another computer, accessing the DH shared secret would make it much easier (and more secure) for the users when they don't also have to write additional nonce, ciphertext and tag to decrypt CSPRNG spawned shared secret key.

The reason I can't continuously use public key crypto box is lack of forward secrecy. So I want to use PyNaCl DH shared key, and refresh the shared secret key using HKDF after every message, creating a forward secret protocol similar to Silent Circle's SCIMP (and in some ways similar to Axolotl used in Signal).

Regarding code:
I'm sure you have your own variable naming policy (every class method seemed to be single word only, so feel free to change it and/or the functionality). I think it should also be verified that the shared key can be used on itself (and not e.g. after running it through hash / KDF) first.

-Markus