### PR TITLE
Signing.py: Name and hide {Public,Private}Key import to avoid confusion

### DIFF
--- a/src/nacl/signing.py
+++ b/src/nacl/signing.py
@@ -102,7 +102,7 @@ class VerifyKey(encoding.Encodable, StringFixer, object):
 
         return nacl.bindings.crypto_sign_open(smessage, self._key)
 
-    def to_public_key(self):
+    def to_curve25519_public_key(self):
         """
         Converts a :class:`~nacl.signing.VerifyKey` to a
         :class:`~nacl.public.PublicKey`
@@ -183,7 +183,7 @@ class SigningKey(encoding.Encodable, StringFixer, object):
 
         return SignedMessage._from_parts(signature, message, signed)
 
-    def to_private_key(self):
+    def to_curve25519_private_key(self):
         """
         Converts a :class:`~nacl.signing.SigningKey` to a
         :class:`~nacl.public.PrivateKey`

--- a/src/nacl/signing.py
+++ b/src/nacl/signing.py
@@ -19,7 +19,8 @@ import six
 from nacl import encoding
 
 import nacl.bindings
-from nacl.public import PrivateKey, PublicKey
+from nacl.public import (PrivateKey as _Curve25519_PrivateKey,
+                         PublicKey as _Curve25519_PublicKey)
 from nacl.utils import StringFixer, random
 
 
@@ -109,7 +110,7 @@ class VerifyKey(encoding.Encodable, StringFixer, object):
         :rtype: :class:`~nacl.public.PublicKey`
         """
         raw_pk = nacl.bindings.crypto_sign_ed25519_pk_to_curve25519(self._key)
-        return PublicKey(raw_pk)
+        return _Curve25519_PublicKey(raw_pk)
 
 
 class SigningKey(encoding.Encodable, StringFixer, object):
@@ -191,4 +192,4 @@ class SigningKey(encoding.Encodable, StringFixer, object):
         """
         sk = self._signing_key
         raw_private = nacl.bindings.crypto_sign_ed25519_sk_to_curve25519(sk)
-        return PrivateKey(raw_private)
+        return _Curve25519_PrivateKey(raw_private)

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -142,8 +142,8 @@ class TestVerifyKey:
         signing_key = SigningKey(binascii.unhexlify(keypair_seed))
         verify_key = signing_key.verify_key
 
-        private_key = bytes(signing_key.to_private_key())
-        public_key = bytes(verify_key.to_public_key())
+        private_key = bytes(signing_key.to_curve25519_private_key())
+        public_key = bytes(verify_key.to_curve25519_public_key())
 
         assert tohex(private_key) == ("8052030376d47112be7f73ed7a019293"
                                       "dd12ad910b654455798b4667d73de166")


### PR DESCRIPTION
From @warner's feedback, we'll hide these imports to avoid accidental use.