### PR TITLE
Add getter for Curve25519 shared secret

### DIFF
--- a/docs/public.rst
+++ b/docs/public.rst
@@ -167,3 +167,15 @@ Reference
         :param encoder: A class that is able to decode the plaintext.
 
         :return bytes: The decrypted plaintext.
+
+    .. method:: shared_key()
+
+        Returns the Curve25519 shared secret, that can then be used as a key in
+        other symmetric ciphers.
+
+        .. warning:: It is **VITALLY** important that you use a nonce with your
+            symmetric cipher. If you fail to do this, you compromise the
+            privacy of the messages encrypted. Ensure that the key length of
+            your cipher is 32 bytes.
+
+        :return bytes: The shared secret.

--- a/src/nacl/public.py
+++ b/src/nacl/public.py
@@ -202,3 +202,18 @@ class Box(encoding.Encodable, StringFixer, object):
         )
 
         return plaintext
+
+    def shared_key(self):
+        """
+        Returns the Curve25519 shared secret, that can then be used as a key in
+        other symmetric ciphers.
+
+        .. warning:: It is **VITALLY** important that you use a nonce with your
+            symmetric cipher. If you fail to do this, you compromise the
+            privacy of the messages encrypted. Ensure that the key length of
+            your cipher is 32 bytes.
+        :rtype: [:class:`bytes`]
+        """
+
+        return self._shared_key
+

--- a/src/nacl/public.py
+++ b/src/nacl/public.py
@@ -216,4 +216,3 @@ class Box(encoding.Encodable, StringFixer, object):
         """
 
         return self._shared_key
-


### PR DESCRIPTION
Moving the discussion from #147 to here. 

The pull request is now under it's own branch. @reaperhulk asked me to write some documentation so I added a section to public.rst plus a docstring, that warn user to use a symmetric cipher with nonce and 32-byte keys.
