### PR TITLE
Add external entropy source for private key generation

### DIFF
--- a/docs/public.rst
+++ b/docs/public.rst
@@ -112,9 +112,12 @@ Reference
         An instance of :class:`~.nacl.public.PublicKey` that corresponds with
         the private key.
 
-    .. classmethod:: generate()
+    .. classmethod:: generate(ext_e)
 
         Generates a random :class:`~nacl.public.PrivateKey` object
+
+        :param ext_e: Optional external entropy provided by user. XORed with
+            system entropy. If empty, only nacl.utils.random() is used.        
 
         :return: An instance of :class:`~nacl.public.PrivateKey`.
 

--- a/src/nacl/public.py
+++ b/src/nacl/public.py
@@ -82,14 +82,35 @@ class PrivateKey(encoding.Encodable, StringFixer, object):
         return self._private_key
 
     @classmethod
-    def generate(cls):
+    def generate(cls, ext_e=''):
         """
         Generates a random :class:`~nacl.public.PrivateKey` object
 
+        :param ext_e: Optional external entropy provided by user. XORed with
+            system entropy. If empty, only nacl.utils.random() is used.
+
         :rtype: :class:`~nacl.public.PrivateKey`
         """
-        return cls(random(PrivateKey.SIZE), encoder=encoding.RawEncoder)
 
+        if not isinstance(ext_e, bytes):
+            raise TypeError("External entropy provided must be bytes")
+
+        # If no external entropy is provided, create string of zero-bytes.
+        if not ext_e:
+            ext_e = str(bytearray(PrivateKey.SIZE))
+
+        # Verify that external entropy is the proper size.
+        if len(ext_e) != PrivateKey.SIZE:
+            raise ValueError(
+                "External entropy must be exactly %d bytes long"
+                % PrivateKey.SIZE)
+
+        nacl_e = random(PrivateKey.SIZE)
+
+        # XOR nacl.utils.random with ext. entropy / string of zero-bytes.
+        final = ''.join(chr(ord(n) ^ ord(e)) for n, e in zip(nacl_e, ext_e))
+
+        return cls(final, encoder=encoding.RawEncoder)
 
 class Box(encoding.Encodable, StringFixer, object):
     """

--- a/src/nacl/public.py
+++ b/src/nacl/public.py
@@ -82,7 +82,7 @@ class PrivateKey(encoding.Encodable, StringFixer, object):
         return self._private_key
 
     @classmethod
-    def generate(cls, ext_e=''):
+    def generate(cls, ext_e=b''):
         """
         Generates a random :class:`~nacl.public.PrivateKey` object
 


### PR DESCRIPTION
This commit adds an optional parameter for user to easily mix in entropy from external sources:

    ext_entropy = usersOwnEntropyGenerator()
    skbob = PrivateKey.generate(ext_entropy)

If additional entropy is not provided--

    skbob = PrivateKey.generate()

the external key is replaced with zero-bit string that has equal length to PrivateKey.

The mixing itself is done with a simple constant time XOR operation. External entropy is defined before library's own random bits are generated with nacl.utils.random(), thus no weak by accident (or malice) entropy source can negatively affect the quality of final key.

Checks for input length and type ensure user can't misuse the function. I also added a docstring for the variable and documentation for readthedocs.