### PR TITLE
sorting is no longer a relevant requirement when precompiling with cffi

### DIFF
--- a/src/bindings/build.py
+++ b/src/bindings/build.py
@@ -30,11 +30,7 @@ HEADERS = glob.glob(
 # Build our FFI instance
 ffi = FFI()
 
-
-# Add all of our header files, but sort first for consistency of the
-# hash that CFFI generates and uses in the .so filename (the order of
-# glob() results cannot be relied on)
-for header in sorted(HEADERS):
+for header in HEADERS:
     with open(header, "r") as hfile:
         ffi.cdef(hfile.read())
 


### PR DESCRIPTION
There's no more C file generated with a specific hash, etc any more.