### PR TITLE
preliminary windows support via some new flags

### DIFF
--- a/src/bindings/build.py
+++ b/src/bindings/build.py
@@ -14,7 +14,7 @@
 from __future__ import absolute_import, division, print_function
 
 import glob
-import os.path
+import os
 
 from cffi import FFI
 
@@ -34,6 +34,17 @@ for header in HEADERS:
     with open(header, "r") as hfile:
         ffi.cdef(hfile.read())
 
+# we need to easily control a few values for Windows builds
+source = []
+if os.getenv("PYNACL_SODIUM_STATIC") is not None:
+    source.append("#define SODIUM_STATIC")
+
+source.append("#include <sodium.h>")
+
+if os.getenv("PYNACL_SODIUM_LIBRARY_NAME") is not None:
+    libraries = [os.getenv("PYNACL_SODIUM_LIBRARY_NAME")]
+else:
+    libraries = ["sodium"]
 
 # Set our source so that we can actually build our bindings to sodium.
-ffi.set_source("_sodium", "#include <sodium.h>", libraries=["sodium"])
+ffi.set_source("_sodium", "\n".join(source), libraries=libraries)

--- a/src/bindings/build.py
+++ b/src/bindings/build.py
@@ -14,7 +14,8 @@
 from __future__ import absolute_import, division, print_function
 
 import glob
-import os
+import os.path
+import sys
 
 from cffi import FFI
 
@@ -41,8 +42,8 @@ if os.getenv("PYNACL_SODIUM_STATIC") is not None:
 
 source.append("#include <sodium.h>")
 
-if os.getenv("PYNACL_SODIUM_LIBRARY_NAME") is not None:
-    libraries = [os.getenv("PYNACL_SODIUM_LIBRARY_NAME")]
+if sys.platform == "windows":
+    libraries = ["libsodium"]
 else:
     libraries = ["sodium"]
 

--- a/src/bindings/build.py
+++ b/src/bindings/build.py
@@ -35,14 +35,18 @@ for header in HEADERS:
     with open(header, "r") as hfile:
         ffi.cdef(hfile.read())
 
-# we need to easily control a few values for Windows builds
 source = []
+
+# SODIUM_STATIC controls the visibility of symbols in the headers. (see
+# export.h in the libsodium source tree). If you do not set SODIUM_STATIC
+# when linking against the static library in Windows then the compile will
+# fail with no symbols found.
 if os.getenv("PYNACL_SODIUM_STATIC") is not None:
     source.append("#define SODIUM_STATIC")
 
 source.append("#include <sodium.h>")
 
-if sys.platform == "windows":
+if sys.platform == "win32":
     libraries = ["libsodium"]
 else:
     libraries = ["sodium"]

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ deps =
     pytest
     coverage
     pretend
-passenv = PYNACL_SODIUM_STATIC LIB INCLUDE
+passenv = SODIUM_INSTALL PYNACL_SODIUM_STATIC LIB INCLUDE
 commands =
     coverage run --source nacl --branch -m pytest
     coverage report -m

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ deps =
     pytest
     coverage
     pretend
+passenv = PYNACL_SODIUM_STATIC LIB INCLUDE
 commands =
     coverage run --source nacl --branch -m pytest
     coverage report -m


### PR DESCRIPTION
PYNACL_SODIUM_LIBRARY_NAME lets you set what it should be trying to link against.

PYNACL_SODIUM_STATIC will define SODIUM_STATIC before include to set the proper dllexport visibility for static linking on windows.

This PR also should be tested by a new jenkins job... let's see if it works.