### PR TITLE
Don't fail if sodium is already initialized.

### DIFF
--- a/src/nacl/bindings/sodium_core.py
+++ b/src/nacl/bindings/sodium_core.py
@@ -22,5 +22,5 @@ def sodium_init():
     Initializes sodium, picking the best implementations available for this
     machine.
     """
-    if lib.sodium_init() != 0:
+    if lib.sodium_init() == -1:
         raise CryptoError("Could not initialize sodium")


### PR DESCRIPTION
No reason to fail if sodium is already initialized.

From the sodium docs (https://download.libsodium.org/doc/usage/index.html):

```
sodium_init() initializes the library and should be called before any other function provided by Sodium. The function can be called more than once, but it should not be executed by multiple threads simultaneously. Add appropriate locks around the function call if this scenario can happen in your application.
```

This should address https://github.com/pyca/pynacl/issues/186 .
