### PR TITLE
Move import nacl.bindings to pleaase flake8 import checker

### DIFF
--- a/src/nacl/public.py
+++ b/src/nacl/public.py
@@ -14,8 +14,8 @@
 
 from __future__ import absolute_import, division, print_function
 
-from nacl import encoding
 import nacl.bindings
+from nacl import encoding
 from nacl.utils import EncryptedMessage, StringFixer, random
 
 

--- a/src/nacl/secret.py
+++ b/src/nacl/secret.py
@@ -14,8 +14,8 @@
 
 from __future__ import absolute_import, division, print_function
 
-from nacl import encoding
 import nacl.bindings
+from nacl import encoding
 from nacl.utils import EncryptedMessage, StringFixer
 
 

--- a/src/nacl/signing.py
+++ b/src/nacl/signing.py
@@ -16,9 +16,9 @@ from __future__ import absolute_import, division, print_function
 
 import six
 
+import nacl.bindings
 from nacl import encoding
 
-import nacl.bindings
 from nacl.public import (PrivateKey as _Curve25519_PrivateKey,
                          PublicKey as _Curve25519_PublicKey)
 from nacl.utils import StringFixer, random


### PR DESCRIPTION
before from nacl import(s), the falke8 run failed as follows:
And fix the "meta" travis target, avoiding the following error on travis checks:

meta runtests: commands[0] | flake8 .
./src/nacl/public.py:18:1: I100 Import statements are in the wrong order.import nacl.bindings should be before from nacl
./src/nacl/secret.py:18:1: I100 Import statements are in the wrong order.import nacl.bindings should be before from nacl
./src/nacl/signing.py:21:1: I100 Import statements are in the wrong order.import nacl.bindings should be before from nacl
ERROR: InvocationError: '/home/travis/build/lmctv/pynacl/.tox/meta/bin/flake8 .'
___________________________________ summary ____________________________________
ERROR:   meta: commands failed
The command ".travis/run.sh" exited with 1.