### PR TITLE
Set default python interpreter version to 3.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: python
-python: 2.7
+python: 3.5
 group: edge
 dist: trusty
 env:


### PR DESCRIPTION
This avoid tox errors on TOXENV=py35 on newly-created (container-based) travis builds
