### PR TITLE
Add sudo: required

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: python
 python: 2.7
 group: edge
 dist: trusty
+sudo: required
 env:
   - TOXENV=py26 SODIUM_INSTALL=bundled CC=gcc
   - TOXENV=py27 SODIUM_INSTALL=bundled CC=gcc


### PR DESCRIPTION
To force travis builds to run in a fully-virtualized environment with a working sudo command. See:  #194 