### PR TITLE
Finish "Enable checking keys for equality"

### DIFF
--- a/src/nacl/public.py
+++ b/src/nacl/public.py
@@ -46,8 +46,11 @@ class PublicKey(encoding.Encodable, StringFixer, object):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return NotImplemented
+            return False
         return bytes(self) == bytes(other)
+
+    def __ne__(self, other):
+        return not (self == other)
 
 
 class PrivateKey(encoding.Encodable, StringFixer, object):
@@ -88,8 +91,11 @@ class PrivateKey(encoding.Encodable, StringFixer, object):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return NotImplemented
+            return False
         return bytes(self) == bytes(other)
+
+    def __ne__(self, other):
+        return not (self == other)
 
     @classmethod
     def generate(cls):

--- a/src/nacl/public.py
+++ b/src/nacl/public.py
@@ -44,6 +44,11 @@ class PublicKey(encoding.Encodable, StringFixer, object):
     def __bytes__(self):
         return self._public_key
 
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return bytes(self) == bytes(other)
+
 
 class PrivateKey(encoding.Encodable, StringFixer, object):
     """
@@ -80,6 +85,11 @@ class PrivateKey(encoding.Encodable, StringFixer, object):
 
     def __bytes__(self):
         return self._private_key
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return bytes(self) == bytes(other)
 
     @classmethod
     def generate(cls):

--- a/src/nacl/signing.py
+++ b/src/nacl/signing.py
@@ -78,6 +78,11 @@ class VerifyKey(encoding.Encodable, StringFixer, object):
     def __bytes__(self):
         return self._key
 
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return bytes(self) == bytes(other)
+
     def verify(self, smessage, signature=None, encoder=encoding.RawEncoder):
         """
         Verifies the signature of a signed message, returning the message
@@ -153,6 +158,11 @@ class SigningKey(encoding.Encodable, StringFixer, object):
 
     def __bytes__(self):
         return self._seed
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return bytes(self) == bytes(other)
 
     @classmethod
     def generate(cls):

--- a/src/nacl/signing.py
+++ b/src/nacl/signing.py
@@ -80,8 +80,11 @@ class VerifyKey(encoding.Encodable, StringFixer, object):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return NotImplemented
+            return False
         return bytes(self) == bytes(other)
+
+    def __ne__(self, other):
+        return not (self == other)
 
     def verify(self, smessage, signature=None, encoder=encoding.RawEncoder):
         """
@@ -161,8 +164,11 @@ class SigningKey(encoding.Encodable, StringFixer, object):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return NotImplemented
+            return False
         return bytes(self) == bytes(other)
+
+    def __ne__(self, other):
+        return not (self == other)
 
     @classmethod
     def generate(cls):

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -12,29 +12,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 from nacl.bindings import crypto_box_PUBLICKEYBYTES, crypto_box_SECRETKEYBYTES
 from nacl.public import PrivateKey, PublicKey
 
+from utils import TestCase
 
-class TestPublicKey:
-    def test_eq_returns_True_for_identical_keys(self):
+
+class TestPublicKey(TestCase):
+    def test_equal_keys_are_equal(self):
         k1 = PublicKey(b"\x00" * crypto_box_PUBLICKEYBYTES)
         k2 = PublicKey(b"\x00" * crypto_box_PUBLICKEYBYTES)
-        assert k1 == k2
+        self._assert_equal(k1, k1)
+        self._assert_equal(k1, k2)
 
-    def test_eq_returns_False_for_wrong_type(self):
+    @pytest.mark.parametrize('k2', [
+        b"\x00" * crypto_box_PUBLICKEYBYTES
+        PublicKey(b"\x01" * crypto_box_PUBLICKEYBYTES),
+        PublicKey(b"\x00" * (crypto_box_PUBLICKEYBYTES - 1) + b"\x01"),
+    ])
+    def test_different_keys_are_not_equal(self, k2):
         k1 = PublicKey(b"\x00" * crypto_box_PUBLICKEYBYTES)
-        k2 = b"\x00" * crypto_box_PUBLICKEYBYTES
-        assert k1 != k2
+        self._assert_not_equal(k1, k2)
 
 
-class TestPrivateKey:
-    def test_eq_returns_True_for_identical_keys(self):
+class TestPrivateKey(TestCase):
+    def test_equal_keys_are_equal(self):
         k1 = PrivateKey(b"\x00" * crypto_box_SECRETKEYBYTES)
         k2 = PrivateKey(b"\x00" * crypto_box_SECRETKEYBYTES)
-        assert k1 == k2
+        self._assert_equal(k1, k1)
+        self._assert_equal(k1, k2)
 
-    def test_eq_returns_False_for_wrong_type(self):
+    @pytest.mark.parametrize('k2', [
+        b"\x00" * crypto_box_SECRETKEYBYTES
+        PrivateKey(b"\x01" * crypto_box_SECRETKEYBYTES),
+        PrivateKey(b"\x00" * (crypto_box_SECRETKEYBYTES - 1) + b"\x01"),
+    ])
+    def test_different_keys_are_not_equal(self, k2):
         k1 = PrivateKey(b"\x00" * crypto_box_SECRETKEYBYTES)
-        k2 = b"\x00" * crypto_box_SECRETKEYBYTES
-        assert k1 != k2
+        self._assert_not_equal(k1, k2)

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from nacl.bindings import crypto_box_PUBLICKEYBYTES, crypto_box_SECRETKEYBYTES
-from nacl.public import PublicKey, PrivateKey
+from nacl.public import PrivateKey, PublicKey
 
 
 class TestPublicKey:

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -28,7 +28,7 @@ class TestPublicKey(TestCase):
         self._assert_equal(k1, k2)
 
     @pytest.mark.parametrize('k2', [
-        b"\x00" * crypto_box_PUBLICKEYBYTES
+        b"\x00" * crypto_box_PUBLICKEYBYTES,
         PublicKey(b"\x01" * crypto_box_PUBLICKEYBYTES),
         PublicKey(b"\x00" * (crypto_box_PUBLICKEYBYTES - 1) + b"\x01"),
     ])
@@ -45,7 +45,7 @@ class TestPrivateKey(TestCase):
         self._assert_equal(k1, k2)
 
     @pytest.mark.parametrize('k2', [
-        b"\x00" * crypto_box_SECRETKEYBYTES
+        b"\x00" * crypto_box_SECRETKEYBYTES,
         PrivateKey(b"\x01" * crypto_box_SECRETKEYBYTES),
         PrivateKey(b"\x00" * (crypto_box_SECRETKEYBYTES - 1) + b"\x01"),
     ])

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -14,10 +14,10 @@
 
 import pytest
 
+from utils import TestCase
+
 from nacl.bindings import crypto_box_PUBLICKEYBYTES, crypto_box_SECRETKEYBYTES
 from nacl.public import PrivateKey, PublicKey
-
-from utils import TestCase
 
 
 class TestPublicKey(TestCase):

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -1,0 +1,40 @@
+# Copyright 2013 Donald Stufft and individual contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nacl.bindings import crypto_box_PUBLICKEYBYTES, crypto_box_SECRETKEYBYTES
+from nacl.public import PublicKey, PrivateKey
+
+
+class TestPublicKey:
+    def test_eq_returns_True_for_identical_keys(self):
+        k1 = PublicKey(b"\x00" * crypto_box_PUBLICKEYBYTES)
+        k2 = PublicKey(b"\x00" * crypto_box_PUBLICKEYBYTES)
+        assert k1 == k2
+
+    def test_eq_returns_False_for_wrong_type(self):
+        k1 = PublicKey(b"\x00" * crypto_box_PUBLICKEYBYTES)
+        k2 = b"\x00" * crypto_box_PUBLICKEYBYTES
+        assert k1 != k2
+
+
+class TestPrivateKey:
+    def test_eq_returns_True_for_identical_keys(self):
+        k1 = PrivateKey(b"\x00" * crypto_box_SECRETKEYBYTES)
+        k2 = PrivateKey(b"\x00" * crypto_box_SECRETKEYBYTES)
+        assert k1 == k2
+
+    def test_eq_returns_False_for_wrong_type(self):
+        k1 = PrivateKey(b"\x00" * crypto_box_SECRETKEYBYTES)
+        k2 = b"\x00" * crypto_box_SECRETKEYBYTES
+        assert k1 != k2

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -20,12 +20,12 @@ import os
 
 import pytest
 
+from utils import TestCase
+
 from nacl.bindings import crypto_sign_PUBLICKEYBYTES, crypto_sign_SEEDBYTES
 from nacl.encoding import HexEncoder
 from nacl.exceptions import BadSignatureError
 from nacl.signing import SignedMessage, SigningKey, VerifyKey
-
-from utils import TestCase
 
 
 def tohex(b):

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -63,6 +63,16 @@ class TestSigningKey:
         k = SigningKey(b"\x00" * crypto_sign_SEEDBYTES)
         assert bytes(k) == b"\x00" * crypto_sign_SEEDBYTES
 
+    def test_eq_returns_True_for_identical_keys(self):
+        k1 = SigningKey(b"\x00" * crypto_sign_SEEDBYTES)
+        k2 = SigningKey(b"\x00" * crypto_sign_SEEDBYTES)
+        assert k1 == k2
+
+    def test_eq_returns_False_for_wrong_type(self):
+        k1 = SigningKey(b"\x00" * crypto_sign_SEEDBYTES)
+        k2 = b"\x00" * crypto_sign_SEEDBYTES
+        assert k1 != k2
+
     @pytest.mark.parametrize("seed", [
         b"77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a",
     ])
@@ -99,6 +109,16 @@ class TestVerifyKey:
     def test_bytes(self):
         k = VerifyKey(b"\x00" * crypto_sign_PUBLICKEYBYTES)
         assert bytes(k) == b"\x00" * crypto_sign_PUBLICKEYBYTES
+
+    def test_eq_returns_True_for_identical_keys(self):
+        k1 = VerifyKey(b"\x00" * crypto_sign_PUBLICKEYBYTES)
+        k2 = VerifyKey(b"\x00" * crypto_sign_PUBLICKEYBYTES)
+        assert k1 == k2
+
+    def test_eq_returns_False_for_wrong_type(self):
+        k1 = VerifyKey(b"\x00" * crypto_sign_PUBLICKEYBYTES)
+        k2 = b"\x00" * crypto_sign_PUBLICKEYBYTES
+        assert k1 != k2
 
     @pytest.mark.parametrize(
         ("public_key", "signed", "message", "signature"),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 class TestCase(object):
     """
     Helper class that provides some extra methods for testing equality
@@ -20,7 +21,7 @@ class TestCase(object):
     def _assert_equal(self, x, y):
         assert x == y
         assert not (x != y)
-    
+
     def _assert_not_equal(self, x, y):
         assert x != y
         assert not (x == y)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,26 @@
+# Copyright 2013 Donald Stufft and individual contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class TestCase(object):
+    """
+    Helper class that provides some extra methods for testing equality
+    methods.
+    """
+    def _assert_equal(self, x, y):
+        assert x == y
+        assert not (x != y)
+    
+    def _assert_not_equal(self, x, y):
+        assert x != y
+        assert not (x == y)


### PR DESCRIPTION
This picks up where #136 left off, in particular adding `__ne__` methods and a bit more testing.

With apologies for stealing @codethief‘s thunder, but after eighteen months I thought it would probably be okay to pick it up and finish it off.

This fixes #134.
