### PR TITLE
Generate random nonces if omitted in encryption calls

### DIFF
--- a/src/nacl/public.py
+++ b/src/nacl/public.py
@@ -139,10 +139,11 @@ class Box(encoding.Encodable, StringFixer, object):
 
         return box
 
-    def encrypt(self, plaintext, nonce, encoder=encoding.RawEncoder):
+    def encrypt(self, plaintext, nonce=None, encoder=encoding.RawEncoder):
         """
-        Encrypts the plaintext message using the given `nonce` and returns
-        the ciphertext encoded with the encoder.
+        Encrypts the plaintext message using the given `nonce` (or generates
+        one randomly if omitted) and returns the ciphertext encoded with the
+        encoder.
 
         .. warning:: It is **VITALLY** important that the nonce is a nonce,
             i.e. it is a number used only once for any given key. If you fail
@@ -153,6 +154,9 @@ class Box(encoding.Encodable, StringFixer, object):
         :param encoder: The encoder to use to encode the ciphertext
         :rtype: [:class:`nacl.utils.EncryptedMessage`]
         """
+        if nonce is None:
+            nonce = random(self.NONCE_SIZE)
+
         if len(nonce) != self.NONCE_SIZE:
             raise ValueError("The nonce must be exactly %s bytes long" %
                              self.NONCE_SIZE)

--- a/src/nacl/secret.py
+++ b/src/nacl/secret.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import, division, print_function
 
 import nacl.bindings
 from nacl import encoding
-from nacl.utils import EncryptedMessage, StringFixer
+from nacl.utils import EncryptedMessage, StringFixer, random
 
 
 class SecretBox(encoding.Encodable, StringFixer, object):
@@ -58,10 +58,11 @@ class SecretBox(encoding.Encodable, StringFixer, object):
     def __bytes__(self):
         return self._key
 
-    def encrypt(self, plaintext, nonce, encoder=encoding.RawEncoder):
+    def encrypt(self, plaintext, nonce=None, encoder=encoding.RawEncoder):
         """
-        Encrypts the plaintext message using the given nonce and returns the
-        ciphertext encoded with the encoder.
+        Encrypts the plaintext message using the given `nonce` (or generates
+        one randomly if omitted) and returns the ciphertext encoded with the
+        encoder.
 
         .. warning:: It is **VITALLY** important that the nonce is a nonce,
             i.e. it is a number used only once for any given key. If you fail
@@ -74,6 +75,9 @@ class SecretBox(encoding.Encodable, StringFixer, object):
         :param encoder: The encoder to use to encode the ciphertext
         :rtype: [:class:`nacl.utils.EncryptedMessage`]
         """
+        if nonce is None:
+            nonce = random(self.NONCE_SIZE)
+
         if len(nonce) != self.NONCE_SIZE:
             raise ValueError(
                 "The nonce must be exactly %s bytes long" % self.NONCE_SIZE,

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -173,10 +173,7 @@ def test_box_optional_nonce(
 
     box = Box(privalice, pubbob)
 
-    encrypted = box.encrypt(
-        binascii.unhexlify(plaintext),
-        encoder=HexEncoder,
-    )
+    encrypted = box.encrypt(binascii.unhexlify(plaintext), encoder=HexEncoder)
 
     decrypted = binascii.hexlify(box.decrypt(encrypted, encoder=HexEncoder))
 

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -166,6 +166,30 @@ def test_box_decryption_combined(
     ),
     VECTORS,
 )
+def test_box_optional_nonce(
+        privalice, pubalice, privbob, pubbob, nonce, plaintext, ciphertext):
+    pubbob = PublicKey(pubbob, encoder=HexEncoder)
+    privalice = PrivateKey(privalice, encoder=HexEncoder)
+
+    box = Box(privalice, pubbob)
+
+    encrypted = box.encrypt(
+        binascii.unhexlify(plaintext),
+        encoder=HexEncoder,
+    )
+
+    decrypted = binascii.hexlify(box.decrypt(encrypted, encoder=HexEncoder))
+
+    assert decrypted == plaintext
+
+
+@pytest.mark.parametrize(
+    (
+        "privalice", "pubalice", "privbob", "pubbob", "nonce", "plaintext",
+        "ciphertext",
+    ),
+    VECTORS,
+)
 def test_box_failed_decryption(
         privalice, pubalice, privbob, pubbob, nonce, plaintext, ciphertext):
     pubbob = PublicKey(pubbob, encoder=HexEncoder)

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -190,6 +190,29 @@ def test_box_optional_nonce(
     ),
     VECTORS,
 )
+def test_box_encryption_generates_different_nonces(
+        privalice, pubalice, privbob, pubbob, nonce, plaintext, ciphertext):
+    pubbob = PublicKey(pubbob, encoder=HexEncoder)
+    privalice = PrivateKey(privalice, encoder=HexEncoder)
+
+    box = Box(privalice, pubbob)
+
+    nonce_0 = box.encrypt(binascii.unhexlify(plaintext),
+                          encoder=HexEncoder).nonce
+
+    nonce_1 = box.encrypt(binascii.unhexlify(plaintext),
+                          encoder=HexEncoder).nonce
+
+    assert nonce_0 != nonce_1
+
+
+@pytest.mark.parametrize(
+    (
+        "privalice", "pubalice", "privbob", "pubbob", "nonce", "plaintext",
+        "ciphertext",
+    ),
+    VECTORS,
+)
 def test_box_failed_decryption(
         privalice, pubalice, privbob, pubbob, nonce, plaintext, ciphertext):
     pubbob = PublicKey(pubbob, encoder=HexEncoder)

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -97,6 +97,22 @@ def test_secret_box_decryption_combined(key, nonce, plaintext, ciphertext):
     assert decrypted == plaintext
 
 
+@pytest.mark.parametrize(("key", "nonce", "plaintext", "ciphertext"), VECTORS)
+def test_secret_box_optional_nonce(key, nonce, plaintext, ciphertext):
+    box = SecretBox(key, encoder=HexEncoder)
+
+    encrypted = box.encrypt(
+        binascii.unhexlify(plaintext),
+        encoder=HexEncoder,
+    )
+
+    decrypted = binascii.hexlify(
+        box.decrypt(encrypted, encoder=HexEncoder),
+    )
+
+    assert decrypted == plaintext
+
+
 def test_secret_box_wrong_lengths():
     with pytest.raises(ValueError):
         SecretBox(b"")

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -113,6 +113,20 @@ def test_secret_box_optional_nonce(key, nonce, plaintext, ciphertext):
     assert decrypted == plaintext
 
 
+@pytest.mark.parametrize(("key", "nonce", "plaintext", "ciphertext"), VECTORS)
+def test_secret_box_encryption_generates_different_nonces(
+        key, nonce, plaintext, ciphertext):
+    box = SecretBox(key, encoder=HexEncoder)
+
+    nonce_0 = box.encrypt(binascii.unhexlify(plaintext),
+                          encoder=HexEncoder).nonce
+
+    nonce_1 = box.encrypt(binascii.unhexlify(plaintext),
+                          encoder=HexEncoder).nonce
+
+    assert nonce_0 != nonce_1
+
+
 def test_secret_box_wrong_lengths():
     with pytest.raises(ValueError):
         SecretBox(b"")

--- a/tests/test_secret.py
+++ b/tests/test_secret.py
@@ -101,14 +101,9 @@ def test_secret_box_decryption_combined(key, nonce, plaintext, ciphertext):
 def test_secret_box_optional_nonce(key, nonce, plaintext, ciphertext):
     box = SecretBox(key, encoder=HexEncoder)
 
-    encrypted = box.encrypt(
-        binascii.unhexlify(plaintext),
-        encoder=HexEncoder,
-    )
+    encrypted = box.encrypt(binascii.unhexlify(plaintext), encoder=HexEncoder)
 
-    decrypted = binascii.hexlify(
-        box.decrypt(encrypted, encoder=HexEncoder),
-    )
+    decrypted = binascii.hexlify(box.decrypt(encrypted, encoder=HexEncoder))
 
     assert decrypted == plaintext
 


### PR DESCRIPTION
Hello!

I agree with @dstufft on #21 that nonces could be generated by default, as well as with @warner on the first solution he mentioned:

> One option we discussed on IRC was:
>
> - use a random nonce unless you call `encypt()` with a `nonce=` kwarg

How do you think this could be tested? I wrote one test for each method that just encrypts, decrypts and compares with the expected plaintext. Another test could work similarly to `test_random_bytes_produces_different_bytes` from `test_utils.py`, encrypting twice and making sure the nonces are different.

Could this be useful?

Thanks!