### PR TITLE
return the byte string as a str in py3

### DIFF
--- a/src/nacl/utils.py
+++ b/src/nacl/utils.py
@@ -51,7 +51,7 @@ class StringFixer(object):
 
     def __str__(self):
         if six.PY3:
-            return self.__unicode__()
+            return str(self.__bytes__())
         else:
             return self.__bytes__()
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,6 +14,7 @@
 
 from __future__ import absolute_import, division, print_function
 
+import nacl.secret
 import nacl.utils
 
 
@@ -23,3 +24,7 @@ def test_random_bytes_produces():
 
 def test_random_bytes_produces_different_bytes():
     assert nacl.utils.random(16) != nacl.utils.random(16)
+
+
+def test_string_fixer():
+    assert str(nacl.secret.SecretBox(b"\x00" * 32)) == str(b"\x00" * 32)


### PR DESCRIPTION
This encodes it a bit, but you shouldn't be printing things except for debug anyway.

Fixes #205 