### PR TITLE
Use constant-time comparison in #208 (completing #136)

### DIFF
--- a/src/bindings/utils.h
+++ b/src/bindings/utils.h
@@ -1,0 +1,16 @@
+/* Copyright 2013-2017 Donald Stufft and individual contributors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+int sodium_memcmp(const void * const b1_, const void * const b2_, size_t len);

--- a/src/nacl/bindings/__init__.py
+++ b/src/nacl/bindings/__init__.py
@@ -47,6 +47,7 @@ from nacl.bindings.crypto_sign import (
 )
 from nacl.bindings.randombytes import randombytes
 from nacl.bindings.sodium_core import sodium_init
+from nacl.bindings.utils import sodium_memcmp
 
 
 __all__ = [
@@ -100,6 +101,8 @@ __all__ = [
     "randombytes",
 
     "sodium_init",
+
+    "sodium_memcmp",
 ]
 
 # Initialize Sodium

--- a/src/nacl/bindings/utils.py
+++ b/src/nacl/bindings/utils.py
@@ -1,0 +1,41 @@
+# Copyright 2013-2017 Donald Stufft and individual contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import, division, print_function
+
+import nacl.exceptions as exc
+from nacl._sodium import ffi, lib
+from nacl.utils import ensure
+
+
+def sodium_memcmp(inp1, inp2):
+    """
+    Compare contents of two memory regions in constant time
+    """
+    ensure(isinstance(inp1, bytes),
+           raising=exc.TypeError)
+    ensure(isinstance(inp2, bytes),
+           raising=exc.TypeError)
+
+    ln = max(len(inp1), len(inp2))
+
+    buf1 = ffi.new("char []", ln)
+    buf2 = ffi.new("char []", ln)
+
+    ffi.memmove(buf1, inp1, len(inp1))
+    ffi.memmove(buf2, inp2, len(inp2))
+
+    eqL = len(inp1) == len(inp2)
+    eqC = lib.sodium_memcmp(buf1, buf2, ln) == 0
+
+    return eqL and eqC

--- a/src/nacl/exceptions.py
+++ b/src/nacl/exceptions.py
@@ -33,3 +33,7 @@ class RuntimeError(CryptoError, RuntimeError):
 
 class AssertionError(CryptoError, AssertionError):
     pass
+
+
+class TypeError(CryptoError, TypeError):
+    pass

--- a/src/nacl/public.py
+++ b/src/nacl/public.py
@@ -47,7 +47,7 @@ class PublicKey(encoding.Encodable, StringFixer, object):
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
             return False
-        return bytes(self) == bytes(other)
+        return nacl.bindings.sodium_memcmp(bytes(self), bytes(other))
 
     def __ne__(self, other):
         return not (self == other)
@@ -92,7 +92,7 @@ class PrivateKey(encoding.Encodable, StringFixer, object):
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
             return False
-        return bytes(self) == bytes(other)
+        return nacl.bindings.sodium_memcmp(bytes(self), bytes(other))
 
     def __ne__(self, other):
         return not (self == other)

--- a/src/nacl/public.py
+++ b/src/nacl/public.py
@@ -46,8 +46,11 @@ class PublicKey(encoding.Encodable, StringFixer, object):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return NotImplemented
+            return False
         return bytes(self) == bytes(other)
+
+    def __ne__(self, other):
+        return not (self == other)
 
 
 class PrivateKey(encoding.Encodable, StringFixer, object):
@@ -88,8 +91,11 @@ class PrivateKey(encoding.Encodable, StringFixer, object):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return NotImplemented
+            return False
         return bytes(self) == bytes(other)
+
+    def __ne__(self, other):
+        return not (self == other)
 
     @classmethod
     def generate(cls):

--- a/src/nacl/public.py
+++ b/src/nacl/public.py
@@ -44,6 +44,11 @@ class PublicKey(encoding.Encodable, StringFixer, object):
     def __bytes__(self):
         return self._public_key
 
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return bytes(self) == bytes(other)
+
 
 class PrivateKey(encoding.Encodable, StringFixer, object):
     """
@@ -80,6 +85,11 @@ class PrivateKey(encoding.Encodable, StringFixer, object):
 
     def __bytes__(self):
         return self._private_key
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return bytes(self) == bytes(other)
 
     @classmethod
     def generate(cls):

--- a/src/nacl/signing.py
+++ b/src/nacl/signing.py
@@ -78,6 +78,11 @@ class VerifyKey(encoding.Encodable, StringFixer, object):
     def __bytes__(self):
         return self._key
 
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return bytes(self) == bytes(other)
+
     def verify(self, smessage, signature=None, encoder=encoding.RawEncoder):
         """
         Verifies the signature of a signed message, returning the message
@@ -153,6 +158,11 @@ class SigningKey(encoding.Encodable, StringFixer, object):
 
     def __bytes__(self):
         return self._seed
+
+    def __eq__(self, other):
+        if not isinstance(other, self.__class__):
+            return NotImplemented
+        return bytes(self) == bytes(other)
 
     @classmethod
     def generate(cls):

--- a/src/nacl/signing.py
+++ b/src/nacl/signing.py
@@ -80,8 +80,11 @@ class VerifyKey(encoding.Encodable, StringFixer, object):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return NotImplemented
+            return False
         return bytes(self) == bytes(other)
+
+    def __ne__(self, other):
+        return not (self == other)
 
     def verify(self, smessage, signature=None, encoder=encoding.RawEncoder):
         """
@@ -161,8 +164,11 @@ class SigningKey(encoding.Encodable, StringFixer, object):
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
-            return NotImplemented
+            return False
         return bytes(self) == bytes(other)
+
+    def __ne__(self, other):
+        return not (self == other)
 
     @classmethod
     def generate(cls):

--- a/src/nacl/signing.py
+++ b/src/nacl/signing.py
@@ -81,7 +81,7 @@ class VerifyKey(encoding.Encodable, StringFixer, object):
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
             return False
-        return bytes(self) == bytes(other)
+        return nacl.bindings.sodium_memcmp(bytes(self), bytes(other))
 
     def __ne__(self, other):
         return not (self == other)
@@ -165,7 +165,7 @@ class SigningKey(encoding.Encodable, StringFixer, object):
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
             return False
-        return bytes(self) == bytes(other)
+        return nacl.bindings.sodium_memcmp(bytes(self), bytes(other))
 
     def __ne__(self, other):
         return not (self == other)

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -12,29 +12,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import pytest
+
 from nacl.bindings import crypto_box_PUBLICKEYBYTES, crypto_box_SECRETKEYBYTES
 from nacl.public import PrivateKey, PublicKey
 
+from utils import TestCase
 
-class TestPublicKey:
-    def test_eq_returns_True_for_identical_keys(self):
+
+class TestPublicKey(TestCase):
+    def test_equal_keys_are_equal(self):
         k1 = PublicKey(b"\x00" * crypto_box_PUBLICKEYBYTES)
         k2 = PublicKey(b"\x00" * crypto_box_PUBLICKEYBYTES)
-        assert k1 == k2
+        self._assert_equal(k1, k1)
+        self._assert_equal(k1, k2)
 
-    def test_eq_returns_False_for_wrong_type(self):
+    @pytest.mark.parametrize('k2', [
+        b"\x00" * crypto_box_PUBLICKEYBYTES
+        PublicKey(b"\x01" * crypto_box_PUBLICKEYBYTES),
+        PublicKey(b"\x00" * (crypto_box_PUBLICKEYBYTES - 1) + b"\x01"),
+    ])
+    def test_different_keys_are_not_equal(self, k2):
         k1 = PublicKey(b"\x00" * crypto_box_PUBLICKEYBYTES)
-        k2 = b"\x00" * crypto_box_PUBLICKEYBYTES
-        assert k1 != k2
+        self._assert_not_equal(k1, k2)
 
 
-class TestPrivateKey:
-    def test_eq_returns_True_for_identical_keys(self):
+class TestPrivateKey(TestCase):
+    def test_equal_keys_are_equal(self):
         k1 = PrivateKey(b"\x00" * crypto_box_SECRETKEYBYTES)
         k2 = PrivateKey(b"\x00" * crypto_box_SECRETKEYBYTES)
-        assert k1 == k2
+        self._assert_equal(k1, k1)
+        self._assert_equal(k1, k2)
 
-    def test_eq_returns_False_for_wrong_type(self):
+    @pytest.mark.parametrize('k2', [
+        b"\x00" * crypto_box_SECRETKEYBYTES
+        PrivateKey(b"\x01" * crypto_box_SECRETKEYBYTES),
+        PrivateKey(b"\x00" * (crypto_box_SECRETKEYBYTES - 1) + b"\x01"),
+    ])
+    def test_different_keys_are_not_equal(self, k2):
         k1 = PrivateKey(b"\x00" * crypto_box_SECRETKEYBYTES)
-        k2 = b"\x00" * crypto_box_SECRETKEYBYTES
-        assert k1 != k2
+        self._assert_not_equal(k1, k2)

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -13,7 +13,7 @@
 # limitations under the License.
 
 from nacl.bindings import crypto_box_PUBLICKEYBYTES, crypto_box_SECRETKEYBYTES
-from nacl.public import PublicKey, PrivateKey
+from nacl.public import PrivateKey, PublicKey
 
 
 class TestPublicKey:

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -28,7 +28,7 @@ class TestPublicKey(TestCase):
         self._assert_equal(k1, k2)
 
     @pytest.mark.parametrize('k2', [
-        b"\x00" * crypto_box_PUBLICKEYBYTES
+        b"\x00" * crypto_box_PUBLICKEYBYTES,
         PublicKey(b"\x01" * crypto_box_PUBLICKEYBYTES),
         PublicKey(b"\x00" * (crypto_box_PUBLICKEYBYTES - 1) + b"\x01"),
     ])
@@ -45,7 +45,7 @@ class TestPrivateKey(TestCase):
         self._assert_equal(k1, k2)
 
     @pytest.mark.parametrize('k2', [
-        b"\x00" * crypto_box_SECRETKEYBYTES
+        b"\x00" * crypto_box_SECRETKEYBYTES,
         PrivateKey(b"\x01" * crypto_box_SECRETKEYBYTES),
         PrivateKey(b"\x00" * (crypto_box_SECRETKEYBYTES - 1) + b"\x01"),
     ])

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -14,10 +14,10 @@
 
 import pytest
 
+from utils import TestCase
+
 from nacl.bindings import crypto_box_PUBLICKEYBYTES, crypto_box_SECRETKEYBYTES
 from nacl.public import PrivateKey, PublicKey
-
-from utils import TestCase
 
 
 class TestPublicKey(TestCase):

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -1,0 +1,40 @@
+# Copyright 2013 Donald Stufft and individual contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from nacl.bindings import crypto_box_PUBLICKEYBYTES, crypto_box_SECRETKEYBYTES
+from nacl.public import PublicKey, PrivateKey
+
+
+class TestPublicKey:
+    def test_eq_returns_True_for_identical_keys(self):
+        k1 = PublicKey(b"\x00" * crypto_box_PUBLICKEYBYTES)
+        k2 = PublicKey(b"\x00" * crypto_box_PUBLICKEYBYTES)
+        assert k1 == k2
+
+    def test_eq_returns_False_for_wrong_type(self):
+        k1 = PublicKey(b"\x00" * crypto_box_PUBLICKEYBYTES)
+        k2 = b"\x00" * crypto_box_PUBLICKEYBYTES
+        assert k1 != k2
+
+
+class TestPrivateKey:
+    def test_eq_returns_True_for_identical_keys(self):
+        k1 = PrivateKey(b"\x00" * crypto_box_SECRETKEYBYTES)
+        k2 = PrivateKey(b"\x00" * crypto_box_SECRETKEYBYTES)
+        assert k1 == k2
+
+    def test_eq_returns_False_for_wrong_type(self):
+        k1 = PrivateKey(b"\x00" * crypto_box_SECRETKEYBYTES)
+        k2 = b"\x00" * crypto_box_SECRETKEYBYTES
+        assert k1 != k2

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -14,18 +14,18 @@
 
 import pytest
 
-from utils import TestCase
+from utils import assert_equal, assert_not_equal
 
 from nacl.bindings import crypto_box_PUBLICKEYBYTES, crypto_box_SECRETKEYBYTES
 from nacl.public import PrivateKey, PublicKey
 
 
-class TestPublicKey(TestCase):
+class TestPublicKey:
     def test_equal_keys_are_equal(self):
         k1 = PublicKey(b"\x00" * crypto_box_PUBLICKEYBYTES)
         k2 = PublicKey(b"\x00" * crypto_box_PUBLICKEYBYTES)
-        self._assert_equal(k1, k1)
-        self._assert_equal(k1, k2)
+        assert_equal(k1, k1)
+        assert_equal(k1, k2)
 
     @pytest.mark.parametrize('k2', [
         b"\x00" * crypto_box_PUBLICKEYBYTES,
@@ -34,15 +34,15 @@ class TestPublicKey(TestCase):
     ])
     def test_different_keys_are_not_equal(self, k2):
         k1 = PublicKey(b"\x00" * crypto_box_PUBLICKEYBYTES)
-        self._assert_not_equal(k1, k2)
+        assert_not_equal(k1, k2)
 
 
-class TestPrivateKey(TestCase):
+class TestPrivateKey:
     def test_equal_keys_are_equal(self):
         k1 = PrivateKey(b"\x00" * crypto_box_SECRETKEYBYTES)
         k2 = PrivateKey(b"\x00" * crypto_box_SECRETKEYBYTES)
-        self._assert_equal(k1, k1)
-        self._assert_equal(k1, k2)
+        assert_equal(k1, k1)
+        assert_equal(k1, k2)
 
     @pytest.mark.parametrize('k2', [
         b"\x00" * crypto_box_SECRETKEYBYTES,
@@ -51,4 +51,4 @@ class TestPrivateKey(TestCase):
     ])
     def test_different_keys_are_not_equal(self, k2):
         k1 = PrivateKey(b"\x00" * crypto_box_SECRETKEYBYTES)
-        self._assert_not_equal(k1, k2)
+        assert_not_equal(k1, k2)

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -20,7 +20,7 @@ import os
 
 import pytest
 
-from utils import TestCase
+from utils import assert_equal, assert_not_equal
 
 from nacl.bindings import crypto_sign_PUBLICKEYBYTES, crypto_sign_SEEDBYTES
 from nacl.encoding import HexEncoder
@@ -53,7 +53,7 @@ def ed25519_known_answers():
     return answers
 
 
-class TestSigningKey(TestCase):
+class TestSigningKey:
     def test_initialize_with_generate(self):
         SigningKey.generate()
 
@@ -68,8 +68,8 @@ class TestSigningKey(TestCase):
     def test_equal_keys_are_equal(self):
         k1 = SigningKey(b"\x00" * crypto_sign_SEEDBYTES)
         k2 = SigningKey(b"\x00" * crypto_sign_SEEDBYTES)
-        self._assert_equal(k1, k1)
-        self._assert_equal(k1, k2)
+        assert_equal(k1, k1)
+        assert_equal(k1, k2)
 
     @pytest.mark.parametrize('k2', [
         b"\x00" * crypto_sign_SEEDBYTES,
@@ -78,7 +78,7 @@ class TestSigningKey(TestCase):
     ])
     def test_different_keys_are_not_equal(self, k2):
         k1 = SigningKey(b"\x00" * crypto_sign_SEEDBYTES)
-        self._assert_not_equal(k1, k2)
+        assert_not_equal(k1, k2)
 
     @pytest.mark.parametrize("seed", [
         b"77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a",
@@ -108,7 +108,7 @@ class TestSigningKey(TestCase):
         assert signed.signature == signature
 
 
-class TestVerifyKey(TestCase):
+class TestVerifyKey:
     def test_wrong_length(self):
         with pytest.raises(ValueError):
             VerifyKey(b"")
@@ -120,8 +120,8 @@ class TestVerifyKey(TestCase):
     def test_equal_keys_are_equal(self):
         k1 = VerifyKey(b"\x00" * crypto_sign_PUBLICKEYBYTES)
         k2 = VerifyKey(b"\x00" * crypto_sign_PUBLICKEYBYTES)
-        self._assert_equal(k1, k1)
-        self._assert_equal(k1, k2)
+        assert_equal(k1, k1)
+        assert_equal(k1, k2)
 
     @pytest.mark.parametrize('k2', [
         b"\x00" * crypto_sign_PUBLICKEYBYTES,
@@ -130,7 +130,7 @@ class TestVerifyKey(TestCase):
     ])
     def test_different_keys_are_not_equal(self, k2):
         k1 = VerifyKey(b"\x00" * crypto_sign_PUBLICKEYBYTES)
-        self._assert_not_equal(k1, k2)
+        assert_not_equal(k1, k2)
 
     @pytest.mark.parametrize(
         ("public_key", "signed", "message", "signature"),

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -20,12 +20,12 @@ import os
 
 import pytest
 
+from utils import TestCase
+
 from nacl.bindings import crypto_sign_PUBLICKEYBYTES, crypto_sign_SEEDBYTES
 from nacl.encoding import HexEncoder
 from nacl.exceptions import BadSignatureError
 from nacl.signing import SignedMessage, SigningKey, VerifyKey
-
-from utils import TestCase
 
 
 def tohex(b):

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -63,6 +63,16 @@ class TestSigningKey:
         k = SigningKey(b"\x00" * crypto_sign_SEEDBYTES)
         assert bytes(k) == b"\x00" * crypto_sign_SEEDBYTES
 
+    def test_eq_returns_True_for_identical_keys(self):
+        k1 = SigningKey(b"\x00" * crypto_sign_SEEDBYTES)
+        k2 = SigningKey(b"\x00" * crypto_sign_SEEDBYTES)
+        assert k1 == k2
+
+    def test_eq_returns_False_for_wrong_type(self):
+        k1 = SigningKey(b"\x00" * crypto_sign_SEEDBYTES)
+        k2 = b"\x00" * crypto_sign_SEEDBYTES
+        assert k1 != k2
+
     @pytest.mark.parametrize("seed", [
         b"77076d0a7318a57d3c16c17251b26645df4c2f87ebc0992ab177fba51db92c2a",
     ])
@@ -99,6 +109,16 @@ class TestVerifyKey:
     def test_bytes(self):
         k = VerifyKey(b"\x00" * crypto_sign_PUBLICKEYBYTES)
         assert bytes(k) == b"\x00" * crypto_sign_PUBLICKEYBYTES
+
+    def test_eq_returns_True_for_identical_keys(self):
+        k1 = VerifyKey(b"\x00" * crypto_sign_PUBLICKEYBYTES)
+        k2 = VerifyKey(b"\x00" * crypto_sign_PUBLICKEYBYTES)
+        assert k1 == k2
+
+    def test_eq_returns_False_for_wrong_type(self):
+        k1 = VerifyKey(b"\x00" * crypto_sign_PUBLICKEYBYTES)
+        k2 = b"\x00" * crypto_sign_PUBLICKEYBYTES
+        assert k1 != k2
 
     @pytest.mark.parametrize(
         ("public_key", "signed", "message", "signature"),

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+
 class TestCase(object):
     """
     Helper class that provides some extra methods for testing equality
@@ -20,7 +21,7 @@ class TestCase(object):
     def _assert_equal(self, x, y):
         assert x == y
         assert not (x != y)
-    
+
     def _assert_not_equal(self, x, y):
         assert x != y
         assert not (x == y)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,26 @@
+# Copyright 2013 Donald Stufft and individual contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+class TestCase(object):
+    """
+    Helper class that provides some extra methods for testing equality
+    methods.
+    """
+    def _assert_equal(self, x, y):
+        assert x == y
+        assert not (x != y)
+    
+    def _assert_not_equal(self, x, y):
+        assert x != y
+        assert not (x == y)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -17,6 +17,7 @@ def assert_equal(x, y):
     assert x == y
     assert not (x != y)
 
+
 def assert_not_equal(x, y):
     assert x != y
     assert not (x == y)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -13,15 +13,10 @@
 # limitations under the License.
 
 
-class TestCase(object):
-    """
-    Helper class that provides some extra methods for testing equality
-    methods.
-    """
-    def _assert_equal(self, x, y):
-        assert x == y
-        assert not (x != y)
+def assert_equal(x, y):
+    assert x == y
+    assert not (x != y)
 
-    def _assert_not_equal(self, x, y):
-        assert x != y
-        assert not (x == y)
+def assert_not_equal(x, y):
+    assert x != y
+    assert not (x == y)


### PR DESCRIPTION
As proposed by @reaperhulk , I'm adding a bit of icing on #208 cake by binding libsodium's constant-time comparison, and exploiting that binding to replace the standard bytes comparison.

I've kept the previous history from @alexwlchan 's branch intact.