### PR TITLE
Fix a small typo in a docstring.

### DIFF
--- a/src/nacl/signing.py
+++ b/src/nacl/signing.py
@@ -173,7 +173,7 @@ class SigningKey(encoding.Encodable, StringFixer, object):
     @classmethod
     def generate(cls):
         """
-        Generates a random :class:`~nacl.signing.SingingKey` object.
+        Generates a random :class:`~nacl.signing.SigningKey` object.
 
         :rtype: :class:`~nacl.signing.SigningKey`
         """


### PR DESCRIPTION
While adding `__hash__` methods in src/nacl/signing.py I stumbled in this happy typo.
Let's fix it.