### PR TITLE
Add some documentation about scrypt password hashing

### DIFF
--- a/docs/hashing.rst
+++ b/docs/hashing.rst
@@ -101,7 +101,7 @@ Please note that **key stretching procedures** like ``HKDF`` or
 the one outlined in `Key derivation`_ are **not** suited to derive
 a *cryptographically-strong* key from a *low-entropy input* like a plain-text
 password or to compute a strong *long-term stored* hash used as password
-verifier. See the `Password hashing`_ section for some more informations
+verifier. See the :ref:`password-hashing` section for some more informations
 and usage examples of the password hashing constructs provided in
 :py:mod:`~nacl.pw_hash`.
 

--- a/docs/hashing.rst
+++ b/docs/hashing.rst
@@ -101,9 +101,9 @@ Please note that **key stretching procedures** like ``HKDF`` or
 the one outlined in `Key derivation`_ are **not** suited to derive
 a *cryptographically-strong* key from a *low-entropy input* like a plain-text
 password or to compute a strong *long-term stored* hash used as password
-verifier. The :py:mod:`~nacl.pw_hash` module provides implementations of the
-``scrypt`` password hash, suitable both for key generation, and long-term
-password storage.
+verifier. See the `Password hashing`_ section for some more informations
+and usage examples of the password hashing constructs provided in
+:py:mod:`~nacl.pw_hash`.
 
 Message authentication
 ----------------------

--- a/docs/hashing.rst
+++ b/docs/hashing.rst
@@ -103,7 +103,7 @@ a *cryptographically-strong* key from a *low-entropy input* like a plain-text
 password or to compute a strong *long-term stored* hash used as password
 verifier. See the :ref:`password-hashing` section for some more informations
 and usage examples of the password hashing constructs provided in
-:py:mod:`~nacl.pw_hash`.
+:py:mod:`~nacl.pwhash`.
 
 Message authentication
 ----------------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -9,8 +9,8 @@ Contents
 
    public
    secret
-   hashing
    signing
+   hashing
    password_hashing
 
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -11,6 +11,7 @@ Contents
    secret
    hashing
    signing
+   password_hashing
 
 
 Support Features

--- a/docs/password_hashing.rst
+++ b/docs/password_hashing.rst
@@ -1,3 +1,5 @@
+.. _password-hashing:
+
 Password hashing
 ================
 

--- a/docs/password_hashing.rst
+++ b/docs/password_hashing.rst
@@ -3,7 +3,7 @@
 Password hashing
 ================
 
-.. currentmodule:: nacl.pw_hash
+.. currentmodule:: nacl.pwhash
 
 Password hashing and password based key derivation mechanisms in
 actual use are all based on the idea of iterating a hash function
@@ -12,8 +12,8 @@ which is stored along with the hash, and allows verifying a proposed
 password while avoiding clear-text storage.
 
 The latest developments in password hashing have been *memory-hard*
-mechanisms, pioneered by the ``scrypt`` mechanism[SD2012]_, which
-is implemented by functions exposed in :py:mod:`nacl.pw_hash`.
+mechanisms, pioneered by the ``scrypt`` mechanism [SD2012]_, which
+is implemented by functions exposed in :py:mod:`nacl.pwhash`.
 
 
 Scrypt usage
@@ -22,14 +22,14 @@ Scrypt usage
 Password storage and verification
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The :py:func:`~nacl.pw_hash.scryptsalsa208sha256_str` internally
+The :py:func:`~nacl.pwhash.scryptsalsa208sha256_str` internally
 generates a random salt, and returns a scrypt hash already encoded
 in ascii modular crypt format, which can be stored in a shadow-like file::
 
-    >>> import nacl.pw_hash
+    >>> import nacl.pwhash
     >>> password = b'my password'
     >>> for i in range(4):
-    ...     print(nacl.pw_hash.scryptsalsa208sha256_str(password))
+    ...     print(nacl.pwhash.scryptsalsa208sha256_str(password))
     ...
     b'$7$C6..../....p9h...'
     b'$7$C6..../....pVs...'
@@ -38,12 +38,12 @@ in ascii modular crypt format, which can be stored in a shadow-like file::
 
 
 To verify a user-proposed password, the
-:py:func:`~nacl.pw_hash.scryptsalsa208sha256_verify` function
+:py:func:`~nacl.pwhash.scryptsalsa208sha256_verify` function
 extracts the used salt and scrypt memory and operation count parameters
 from the modular format string and checks the compliance of the
 proposed password with the stored hash::
 
-    >>> import nacl.pw_hash
+    >>> import nacl.pwhash
     >>> hashed = (b'$7$C6..../....qv5tF9KG2WbuMeUOa0TCoqwLHQ8s0TjQdSagne'
     ...           b'9NvU0$3d218uChMvdvN6EwSvKHMASkZIG51XPIsZQDcktKyN7'
     ...           )
@@ -51,11 +51,11 @@ proposed password with the stored hash::
     >>> wrong = b'My password'
     >>> # the result will be True on password match
     ... # on mismatch
-    ... res = nacl.pw_hash.verify_scryptsalsa208sha256(hashed, correct)
+    ... res = nacl.pwhash.verify_scryptsalsa208sha256(hashed, correct)
     >>> print(res)
     True
     >>>
-    >>> res2 = nacl.pw_hash.verify_scryptsalsa208sha256(hashed, wrong)
+    >>> res2 = nacl.pwhash.verify_scryptsalsa208sha256(hashed, wrong)
     Traceback (most recent call last):
         ...
     nacl.exceptions.InvalidkeyError: Wrong password
@@ -68,24 +68,24 @@ Key derivation
 Alice needs to send a secret message to Bob, using a shared
 password to protect the content. She generates a random salt,
 combines it with the password using
-:py:func:`~nacl.pw_hash.kdf_scryptsalsa208sha256` and sends
+:py:func:`~nacl.pwhash.kdf_scryptsalsa208sha256` and sends
 the message along with the salt and key derivation parameters.
 
 .. code-block:: python
 
-    from nacl import pw_hash, secret, utils
+    from nacl import pwhash, secret, utils
 
-    ops = pw_hash.SCRYPT_OPSLIMIT_SENSITIVE
-    mem = pw_hash.SCRYPT_MEMLIMIT_SENSITIVE
+    ops = pwhash.SCRYPT_OPSLIMIT_SENSITIVE
+    mem = pwhash.SCRYPT_MEMLIMIT_SENSITIVE
 
-    salt = utils.random(pw_hash.SCRYPT_SALTBYTES)
+    salt = utils.random(pwhash.SCRYPT_SALTBYTES)
 
     password = b'password shared between Alice and Bob'
     message = b"This is a message for Bob's eyes only"
 
-    Alices_key = pw_hash.kdf_scryptsalsa208sha256(secret.SecretBox.KEY_SIZE,
-                                                  password, salt,
-                                                  opslimit=ops, memlimit=mem)
+    Alices_key = pwhash.kdf_scryptsalsa208sha256(secret.SecretBox.KEY_SIZE,
+                                                 password, salt,
+                                                 opslimit=ops, memlimit=mem)
     Alices_box = secret.SecretBox(Alices_key)
     nonce = utils.random(secret.SecretBox.NONCE_SIZE)
 
@@ -97,9 +97,9 @@ the message along with the salt and key derivation parameters.
     # Bob is able to derive the correct key to decrypt the message
 
 
-    Bobs_key = pw_hash.kdf_scryptsalsa208sha256(secret.SecretBox.KEY_SIZE,
-                                                password, salt,
-                                                opslimit=ops, memlimit=mem)
+    Bobs_key = pwhash.kdf_scryptsalsa208sha256(secret.SecretBox.KEY_SIZE,
+                                               password, salt,
+                                               opslimit=ops, memlimit=mem)
     Bobs_box = secret.SecretBox(Bobs_key)
     received = Bobs_box.decrypt(encrypted)
     print(received)
@@ -109,18 +109,18 @@ with a incorrect password, even if she does know all of the key
 derivation parameters, she would derive a different key. Therefore
 the decryption would fail and an exception would be raised::
 
-    >>> from nacl import pw_hash, secret, utils
+    >>> from nacl import pwhash, secret, utils
     >>>
-    >>> ops = pw_hash.SCRYPT_OPSLIMIT_SENSITIVE
-    >>> mem = pw_hash.SCRYPT_MEMLIMIT_SENSITIVE
+    >>> ops = pwhash.SCRYPT_OPSLIMIT_SENSITIVE
+    >>> mem = pwhash.SCRYPT_MEMLIMIT_SENSITIVE
     >>>
-    >>> salt = utils.random(pw_hash.SCRYPT_SALTBYTES)
+    >>> salt = utils.random(pwhash.SCRYPT_SALTBYTES)
     >>>
     >>> guessed_pw = b'I think Alice shared this password with Bob'
     >>>
-    >>> Eves_key = pw_hash.kdf_scryptsalsa208sha256(secret.SecretBox.KEY_SIZE,
-    ...                                             guessed_pw, salt,
-    ...                                             opslimit=ops, memlimit=mem)
+    >>> Eves_key = pwhash.kdf_scryptsalsa208sha256(secret.SecretBox.KEY_SIZE,
+    ...                                            guessed_pw, salt,
+    ...                                            opslimit=ops, memlimit=mem)
     >>> Eves_box = secret.SecretBox(Eves_key)
     >>> intercepted = Eves_box.decrypt(encrypted)
     Traceback (most recent call last):

--- a/docs/password_hashing.rst
+++ b/docs/password_hashing.rst
@@ -1,0 +1,134 @@
+Password hashing
+================
+
+.. currentmodule:: nacl.pw_hash
+
+An ever important use of cryptographic hashing primitives has been
+the password hashing one, starting from the early 1970's years, at
+first just to avoid storing clear-text passwords.
+
+To make a long story short [SD2012]_, password hashing and password based key
+derivation mechanisms in actual use are all based on the idea of iterating
+many times a hash function on a combination of the password and
+a random ``salt`` which is stored along with the hash, and allows
+verifying a proposed password while avoiding clear-text storage.
+
+The latest developments in password hashing have been mechanisms
+pionereed by the ``scrypt`` mechanism, which is implemented by functions
+exposed in :py:mod:`nacl.pw_hash`.
+
+
+Scrypt usage
+------------
+
+Password storage and verification
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The :py:func:`~nacl.pw_hash.scryptsalsa208sha256_str` does internally
+generate a random salt, and returns a scrypt hash already encoded
+in ascii modular crypt format, which can be stored in a shadow-like file::
+
+    >>> import nacl.pw_hash
+    >>> password = b'my password'
+    >>> for i in range(4):
+    ...     print(nacl.pw_hash.scryptsalsa208sha256_str(password))
+    ...
+    b'$7$C6..../....p9h...'
+    b'$7$C6..../....pVs...'
+    b'$7$C6..../....qW2...'
+    b'$7$C6..../....bxH...'
+
+
+To verify a user-proposed password, the
+:py:func:`~nacl.pw_hash.scryptsalsa208sha256_verify` function
+does extract the used salt and scrypt memory and operation count parameters
+from the modular format string and checks the compliance of the
+proposed password with the stored hash::
+
+    >>> import nacl.pw_hash
+    >>> hashed = (b'$7$C6..../....qv5tF9KG2WbuMeUOa0TCoqwLHQ8s0TjQdSagne'
+    ...           b'9NvU0$3d218uChMvdvN6EwSvKHMASkZIG51XPIsZQDcktKyN7'
+    ...           )
+    >>> correct = b'my password'
+    >>> wrong = b'My password'
+    >>> # the result will be True on password match
+    ... # on mismatch
+    ... res = nacl.pw_hash.verify_scryptsalsa208sha256(hashed, correct)
+    >>> print(res)
+    True
+    >>>
+    >>> res2 = nacl.pw_hash.verify_scryptsalsa208sha256(hashed, wrong)
+    Traceback (most recent call last):
+        ...
+    nacl.exceptions.InvalidkeyError: Wrong password
+    >>>
+
+
+Key derivation
+~~~~~~~~~~~~~~
+
+If Alice needs to send a secret message to Bob, using a shared
+password to protect the content, she can use a salt, which she
+must then send along to the message, to derive a cryptographically
+strong key using :py:func:`~nacl.pw_hash.kdf_scryptsalsa208sha256`:
+
+.. code-block:: python
+
+    from nacl import pw_hash, secret, utils
+
+    ops = pw_hash.SCRYPT_OPSLIMIT_SENSITIVE
+    mem = pw_hash.SCRYPT_MEMLIMIT_SENSITIVE
+
+    salt = utils.random(pw_hash.SCRYPT_SALTBYTES)
+
+    password = b'password shared between Alice and Bob'
+    message = b"This is a message for Bob's eyes only"
+
+    Alices_key = pw_hash.kdf_scryptsalsa208sha256(secret.SecretBox.KEY_SIZE,
+                                                  password, salt,
+                                                  opslimit=ops, memlimit=mem)
+    Alices_box = secret.SecretBox(Alices_key)
+    nonce = utils.random(secret.SecretBox.NONCE_SIZE)
+
+    encrypted = Alices_box.encrypt(message, nonce)
+
+    # now Alice must send to Bob both the encrypted message
+    # and the KDF parameters: salt, opslimit and memlimit
+    # using the same parameters **and password**
+    # Bob is able to derive the correct key to decrypt the message
+
+
+    Bobs_key = pw_hash.kdf_scryptsalsa208sha256(secret.SecretBox.KEY_SIZE,
+                                                password, salt,
+                                                opslimit=ops, memlimit=mem)
+    Bobs_box = secret.SecretBox(Bobs_key)
+    received = Bobs_box.decrypt(encrypted)
+    print(received)
+
+if Eve's manages to get the encrypted message, and tries to decrypt it
+with a wrongly guessed password, even if she does know all of the key
+derivation parameters, she would derive a different key, therefore
+the decryption would fail and an exception would be raised::
+
+    >>> from nacl import pw_hash, secret, utils
+    >>>
+    >>> ops = pw_hash.SCRYPT_OPSLIMIT_SENSITIVE
+    >>> mem = pw_hash.SCRYPT_MEMLIMIT_SENSITIVE
+    >>>
+    >>> salt = utils.random(pw_hash.SCRYPT_SALTBYTES)
+    >>>
+    >>> guessed_pw = b'I think Alice shared this password with Bob'
+    >>>
+    >>> Eves_key = pw_hash.kdf_scryptsalsa208sha256(secret.SecretBox.KEY_SIZE,
+    ...                                             guessed_pw, salt,
+    ...                                             opslimit=ops, memlimit=mem)
+    >>> Eves_box = secret.SecretBox(Eves_key)
+    >>> intercepted = Eves_box.decrypt(encrypted)
+    Traceback (most recent call last):
+        ...
+    nacl.exceptions.CryptoError: Decryption failed. Ciphertext failed ...
+
+.. [SD2012] A nice overview of password hashing history is available
+   in Solar Designer's presentation
+   `Password security: past, present, future
+   <http://www.openwall.com/presentations/Passwords12-The-Future-Of-Hashing/>`_

--- a/docs/password_hashing.rst
+++ b/docs/password_hashing.rst
@@ -5,19 +5,15 @@ Password hashing
 
 .. currentmodule:: nacl.pw_hash
 
-An ever important use of cryptographic hashing primitives has been
-the password hashing one, starting from the early 1970's years, at
-first just to avoid storing clear-text passwords.
+Password hashing and password based key derivation mechanisms in
+actual use are all based on the idea of iterating a hash function
+many times on a combination of the password and a random ``salt``,
+which is stored along with the hash, and allows verifying a proposed
+password while avoiding clear-text storage.
 
-To make a long story short [SD2012]_, password hashing and password based key
-derivation mechanisms in actual use are all based on the idea of iterating
-many times a hash function on a combination of the password and
-a random ``salt`` which is stored along with the hash, and allows
-verifying a proposed password while avoiding clear-text storage.
-
-The latest developments in password hashing have been mechanisms
-pionereed by the ``scrypt`` mechanism, which is implemented by functions
-exposed in :py:mod:`nacl.pw_hash`.
+The latest developments in password hashing have been *memory-hard*
+mechanisms, pioneered by the ``scrypt`` mechanism[SD2012]_, which
+is implemented by functions exposed in :py:mod:`nacl.pw_hash`.
 
 
 Scrypt usage
@@ -26,8 +22,8 @@ Scrypt usage
 Password storage and verification
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The :py:func:`~nacl.pw_hash.scryptsalsa208sha256_str` does internally
-generate a random salt, and returns a scrypt hash already encoded
+The :py:func:`~nacl.pw_hash.scryptsalsa208sha256_str` internally
+generates a random salt, and returns a scrypt hash already encoded
 in ascii modular crypt format, which can be stored in a shadow-like file::
 
     >>> import nacl.pw_hash
@@ -43,7 +39,7 @@ in ascii modular crypt format, which can be stored in a shadow-like file::
 
 To verify a user-proposed password, the
 :py:func:`~nacl.pw_hash.scryptsalsa208sha256_verify` function
-does extract the used salt and scrypt memory and operation count parameters
+extracts the used salt and scrypt memory and operation count parameters
 from the modular format string and checks the compliance of the
 proposed password with the stored hash::
 
@@ -69,10 +65,11 @@ proposed password with the stored hash::
 Key derivation
 ~~~~~~~~~~~~~~
 
-If Alice needs to send a secret message to Bob, using a shared
-password to protect the content, she can use a salt, which she
-must then send along to the message, to derive a cryptographically
-strong key using :py:func:`~nacl.pw_hash.kdf_scryptsalsa208sha256`:
+Alice needs to send a secret message to Bob, using a shared
+password to protect the content. She generates a random salt,
+combines it with the password using
+:py:func:`~nacl.pw_hash.kdf_scryptsalsa208sha256` and sends
+the message along with the salt and key derivation parameters.
 
 .. code-block:: python
 
@@ -107,9 +104,9 @@ strong key using :py:func:`~nacl.pw_hash.kdf_scryptsalsa208sha256`:
     received = Bobs_box.decrypt(encrypted)
     print(received)
 
-if Eve's manages to get the encrypted message, and tries to decrypt it
-with a wrongly guessed password, even if she does know all of the key
-derivation parameters, she would derive a different key, therefore
+if Eve manages to get the encrypted message, and tries to decrypt it
+with a incorrect password, even if she does know all of the key
+derivation parameters, she would derive a different key. Therefore
 the decryption would fail and an exception would be raised::
 
     >>> from nacl import pw_hash, secret, utils

--- a/src/nacl/pwhash.py
+++ b/src/nacl/pwhash.py
@@ -110,7 +110,7 @@ def verify_scryptsalsa208sha256(password_hash, password):
     """
 
     ensure(len(password_hash) == SCRYPT_PWHASH_SIZE,
-           "The pw_hash must be exactly %s bytes long" %
+           "The password hash must be exactly %s bytes long" %
            nacl.bindings.crypto_pwhash_scryptsalsa208sha256_STRBYTES,
            raising=exc.ValueError)
 


### PR DESCRIPTION
The trivial merge conflict with #217 can be solved in a couple of minutes.

While writing the documentation, I became aware of a couple of changes I think that could have some merit:
 - If #217 does get merged, I'd like to move the python3.6 compatible scrypt() function to nacl.hashlib,
   which would become a common container for python3.6 compatible implementations
 - I'm unsure I still like the underscore in pw_hash name, and I think I'd prefer to replace the module
   name with pwhash before the next version gets released