### PR TITLE
Pin pyenv at the last known-working commit

### DIFF
--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -3,6 +3,14 @@
 set -e
 set -x
 
+# pin pyenv at the last known good release
+PYENV_COMMIT=99d16707e372143fb35d822c26fe8427719b903c
+
+# the following commit breaks tox virtualenv building
+# on travis-ci
+#
+# PYENV_COMMIT=2657f1049cd45656918f601096509957d5b74e7c
+
 if [[ $SODIUM_INSTALL == 'system' ]]; then
     wget https://download.libsodium.org/libsodium/releases/LATEST.tar.gz
     tar zxvf LATEST.tar.gz
@@ -17,6 +25,7 @@ fi
 if [[ "${TOXENV}" == "pypy" ]]; then
     rm -rf ~/.pyenv
     git clone https://github.com/yyuu/pyenv.git ~/.pyenv
+    git -C  ~/.pyenv reset --hard ${PYENV_COMMIT:-HEAD}
     PYENV_ROOT="$HOME/.pyenv"
     PATH="$PYENV_ROOT/bin:$PATH"
     eval "$(pyenv init -)"
@@ -27,6 +36,7 @@ fi
 if [[ "${TOXENV}" == "py26" ]]; then
     rm -rf ~/.pyenv
     git clone https://github.com/yyuu/pyenv.git ~/.pyenv
+    git -C  ~/.pyenv reset --hard ${PYENV_COMMIT:-HEAD}
     PYENV_ROOT="$HOME/.pyenv"
     PATH="$PYENV_ROOT/bin:$PATH"
     eval "$(pyenv init -)"
@@ -37,6 +47,7 @@ fi
 if [[ "${TOXENV}" == "py33" ]]; then
     rm -rf ~/.pyenv
     git clone https://github.com/yyuu/pyenv.git ~/.pyenv
+    git -C  ~/.pyenv reset --hard ${PYENV_COMMIT:-HEAD}
     PYENV_ROOT="$HOME/.pyenv"
     PATH="$PYENV_ROOT/bin:$PATH"
     eval "$(pyenv init -)"

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -3,13 +3,9 @@
 set -e
 set -x
 
-# pin pyenv at the last known good release
-PYENV_COMMIT=99d16707e372143fb35d822c26fe8427719b903c
-
-# the following commit breaks tox virtualenv building
-# on travis-ci
-#
-# PYENV_COMMIT=2657f1049cd45656918f601096509957d5b74e7c
+# to pin pyenv version, set the PYENV_COMMIT variable
+# to the required version commit identifier/tag like in
+# PYENV_COMMIT=v1.0.7
 
 if [[ $SODIUM_INSTALL == 'system' ]]; then
     wget https://download.libsodium.org/libsodium/releases/LATEST.tar.gz


### PR DESCRIPTION
Commit yyuu/pyenv@2657f1049cd45656918f601096509957d5b74e7c broke virtual environment creation on travis.

Go back to working condition by (temporary) pinning the pyenv version in use to the last working commit.