### PR TITLE
Complete "We do the py36" PR

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,21 +8,25 @@ env:
   - TOXENV=py33 SODIUM_INSTALL=bundled CC=gcc
   - TOXENV=py34 SODIUM_INSTALL=bundled CC=gcc
   - TOXENV=py35 SODIUM_INSTALL=bundled CC=gcc
+  - TOXENV=py36 SODIUM_INSTALL=bundled CC=gcc
   - TOXENV=pypy SODIUM_INSTALL=bundled CC=gcc
   - TOXENV=py27 SODIUM_INSTALL=system CC=gcc
   - TOXENV=py33 SODIUM_INSTALL=system CC=gcc
   - TOXENV=py34 SODIUM_INSTALL=system CC=gcc
   - TOXENV=py35 SODIUM_INSTALL=system CC=gcc
+  - TOXENV=py36 SODIUM_INSTALL=system CC=gcc
   - TOXENV=pypy SODIUM_INSTALL=system CC=gcc
   - TOXENV=py27 SODIUM_INSTALL=bundled CC=clang
   - TOXENV=py33 SODIUM_INSTALL=bundled CC=clang
   - TOXENV=py34 SODIUM_INSTALL=bundled CC=clang
   - TOXENV=py35 SODIUM_INSTALL=bundled CC=clang
+  - TOXENV=py36 SODIUM_INSTALL=bundled CC=clang
   - TOXENV=pypy SODIUM_INSTALL=bundled CC=clang
   - TOXENV=py27 SODIUM_INSTALL=system CC=clang
   - TOXENV=py33 SODIUM_INSTALL=system CC=clang
   - TOXENV=py34 SODIUM_INSTALL=system CC=clang
   - TOXENV=py35 SODIUM_INSTALL=system CC=clang
+  - TOXENV=py36 SODIUM_INSTALL=system CC=clang
   - TOXENV=pypy SODIUM_INSTALL=system CC=clang
   - TOXENV=docs
   - TOXENV=meta

--- a/.travis/install.sh
+++ b/.travis/install.sh
@@ -51,4 +51,15 @@ if [[ "${TOXENV}" == "py33" ]]; then
     pyenv global 3.3.6
 fi
 
+if [[ "${TOXENV}" == "py36" ]]; then
+    rm -rf ~/.pyenv
+    git clone https://github.com/yyuu/pyenv.git ~/.pyenv
+    git -C  ~/.pyenv reset --hard ${PYENV_COMMIT:-HEAD}
+    PYENV_ROOT="$HOME/.pyenv"
+    PATH="$PYENV_ROOT/bin:$PATH"
+    eval "$(pyenv init -)"
+    pyenv install 3.6.0
+    pyenv global 3.6.0
+fi
+
 pip install -U tox coverage

--- a/setup.py
+++ b/setup.py
@@ -229,5 +229,6 @@ setup(
         "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
+        "Programming Language :: Python :: 3.6",
     ]
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,pypy,py33,py34,py35,docs,meta
+envlist = py26,py27,pypy,py33,py34,py35,py36,docs,meta
 
 [testenv]
 deps =


### PR DESCRIPTION
@alex forgot adding the creation of python 3.6 pyenv environment in .travis/install.sh while adding py36 to the test matrix in #224 .

I've already rebased the PR onto #241 to show we **really** do *the py36* 