### PR TITLE
Correct signedness mismatch on the output buffer

### DIFF
--- a/src/nacl/bindings/crypto_pwhash.py
+++ b/src/nacl/bindings/crypto_pwhash.py
@@ -189,7 +189,7 @@ def crypto_pwhash_scryptsalsa208sha256_str(
     :return: serialized key hash, including salt and tuning parameters
     :rtype: bytes
     """
-    buf = ffi.new("unsigned char[]", SCRYPT_STRBYTES)
+    buf = ffi.new("char[]", SCRYPT_STRBYTES)
 
     ret = lib.crypto_pwhash_scryptsalsa208sha256_str(buf, passwd,
                                                      len(passwd),


### PR DESCRIPTION
removing the spurious unsigned qualifier before "char[]", which I didn't notice while rebasing and updating #130 to current cffi implementation.

This silences a warning I've seen only on travis:

```
tests/test_pw_hash.py [...]/nacl/bindings/crypto_pwhash.py:197: UserWarning:
    implicit cast to 'char *' from a different pointer type: will be forbidden
    in the future (check that the types are as you expect; use an explicit ffi.cast()
    if they are correct)
```