### PR TITLE
Update public and secret key encryption docs with optional nonces

### DIFF
--- a/docs/public.rst
+++ b/docs/public.rst
@@ -65,15 +65,31 @@ This is how the system works:
     #   as just a binary blob of data.
     message = b"Kill all humans"
 
+PyNaCl can automatically generate a random nonce for us, making the encryption
+very simple:
+
+.. code-block:: python
+
+    # Encrypt our message, it will be exactly 40 bytes longer than the
+    #   original message as it stores authentication information and the
+    #   nonce alongside it.
+    encrypted = bob_box.encrypt(message)
+
+However, if we need to use an explicit nonce, it can be passed along with the
+message:
+
+.. code-block:: python
+
     # This is a nonce, it *MUST* only be used once, but it is not considered
     #   secret and can be transmitted or stored alongside the ciphertext. A
     #   good source of nonces are just sequences of 24 random bytes.
     nonce = nacl.utils.random(Box.NONCE_SIZE)
 
-    # Encrypt our message, it will be exactly 40 bytes longer than the
-    #   original message as it stores authentication information and the
-    #   nonce alongside it.
     encrypted = bob_box.encrypt(message, nonce)
+
+Finally, the message is decrypted (regardless of how the nonce was generated):
+
+.. code-block:: python
 
     # Alice creates a second box with her private key to decrypt the message
     alice_box = Box(skalice, pkbob)

--- a/docs/secret.rst
+++ b/docs/secret.rst
@@ -31,15 +31,31 @@ Example
     #   treat it as just a binary blob of data.
     message = b"The president will be exiting through the lower levels"
 
+PyNaCl can automatically generate a random nonce for us, making the encryption
+very simple:
+
+.. code-block:: python
+
+    # Encrypt our message, it will be exactly 40 bytes longer than the
+    #   original message as it stores authentication information and the
+    #   nonce alongside it.
+    encrypted = box.encrypt(message)
+
+However, if we need to use an explicit nonce, it can be passed along with the
+message:
+
+.. code-block:: python
+
     # This is a nonce, it *MUST* only be used once, but it is not considered
     #   secret and can be transmitted or stored alongside the ciphertext. A
     #   good source of nonces are just sequences of 24 random bytes.
     nonce = nacl.utils.random(nacl.secret.SecretBox.NONCE_SIZE)
 
-    # Encrypt our message, it will be exactly 40 bytes longer than the
-    #   original message as it stores authentication information and the
-    #   nonce alongside it.
     encrypted = box.encrypt(message, nonce)
+
+Finally, the message is decrypted (regardless of how the nonce was generated):
+
+.. code-block:: python
 
     # Decrypt our message, an exception will be raised if the encryption was
     #   tampered with or there was otherwise an error.


### PR DESCRIPTION
Sorry for taking such a long time to work on this.

I was going to create new examples when using optional nonces as @reaperhulk suggested on #210, but I decided to use the same ones because they would not be too different. What do you think?

The other questions I have are:

- Should we have one example using a counter or some other "kind" of nonce? Currently the examples show how to use a random nonce manually and automatically, and I don't think that makes too much sense.
- This PR first explains how to provide a nonce and then how to use a random one. What order should the examples be presented though?
- I noticed there are four paragraphs about nonces in secret key encryption and not much in public key encryption. Should both have the same information about it?

Thanks!