### PR TITLE
Decode both smessage and signature in VerifyKey.verify()

### DIFF
--- a/src/nacl/signing.py
+++ b/src/nacl/signing.py
@@ -106,10 +106,10 @@ class VerifyKey(encoding.Encodable, StringFixer, object):
         if signature is not None:
             # If we were given the message and signature separately, combine
             #   them.
-            smessage = signature + smessage
-
-        # Decode the signed message
-        smessage = encoder.decode(smessage)
+            smessage = encoder.decode(signature) + encoder.decode(smessage)
+        else:
+            # Decode the signed message
+            smessage = encoder.decode(smessage)
 
         return nacl.bindings.crypto_sign_open(smessage, self._key)
 

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -23,7 +23,7 @@ import pytest
 from utils import assert_equal, assert_not_equal
 
 from nacl.bindings import crypto_sign_PUBLICKEYBYTES, crypto_sign_SEEDBYTES
-from nacl.encoding import HexEncoder
+from nacl.encoding import Base64Encoder, HexEncoder
 from nacl.exceptions import BadSignatureError
 from nacl.signing import SignedMessage, SigningKey, VerifyKey
 
@@ -179,6 +179,34 @@ class TestVerifyKey:
         with pytest.raises(BadSignatureError):
             forged = SignedMessage(signature + message)
             skey.verify_key.verify(forged)
+
+    def test_both_verify_uses_are_equal_with_b64encoder(self):
+        sk = SigningKey.generate()
+        vk = sk.verify_key
+
+        smsg = sk.sign(b"Hello World", encoder=Base64Encoder)
+
+        msg = smsg.message
+        sig = smsg.signature
+
+        assert vk.verify(
+            msg, sig, encoder=Base64Encoder
+        ) == vk.verify(
+            smsg, encoder=Base64Encoder)
+
+    def test_both_verify_uses_are_equal_with_hexencoder(self):
+        sk = SigningKey.generate()
+        vk = sk.verify_key
+
+        smsg = sk.sign(b"Hello World", encoder=HexEncoder)
+
+        msg = smsg.message
+        sig = smsg.signature
+
+        assert vk.verify(
+            msg, sig, encoder=HexEncoder
+        ) == vk.verify(
+            smsg, encoder=HexEncoder)
 
     def test_key_conversion(self):
         keypair_seed = (b"421151a459faeade3d247115f94aedae"


### PR DESCRIPTION
This PR makes it easier to verify messages by properly combining encoded messages and signatures.

Basically it fixes `VerifyKey.verify()` to decode both the `smessage` and `signature` before appending them together. This PR makes it possible to do this:

```python
smsg = sender_signing_key.sign(msg, encoder=Base64Encoder)

verified_msg_1 = sender_verify_key.verify(smsg, encoder=Base64Encoder)  # The sig+msg as smsg

msg = smsg.message  # b64-encoded
sig = smsg.signature  # b64-encoded

verified_msg_2 = sender_verify_key.verify(msg, sig, encoder=Base64Encoder)  # Split msg and sig

assert verified_msg_1 == verified_msg_2
```

It also adds two tests that make sure both ways work and return the same result.