### PR TITLE
Correct typos in scrypt docs

### DIFF
--- a/docs/api/hashlib.rst
+++ b/docs/api/hashlib.rst
@@ -59,7 +59,7 @@ to cpython standard library's hashlib module in cpython's version 3.6.
               scrypt constructs which will contribute to the final key
               generation
     :type p: int
-    :param maxmem: maximum memory the whole scrypt constract will be
+    :param maxmem: maximum memory the whole scrypt construct will be
                    entitled to use
     :type maxmem: int
     :param dklen: length of the derived key
@@ -69,7 +69,7 @@ to cpython standard library's hashlib module in cpython's version 3.6.
     Implements the same signature as the ``hashlib.scrypt`` implemented
     in cpython version 3.6
 
-    The recommended values for n, r, p in 2012 were n: 2**14, r: 8, p: 1
+    The recommended values for n, r, p in 2012 were n = 2**14, r = 8, p = 1;
     as of 2016, libsodium suggests using n = 2**14, r = 8, p = 1
     in a "interactive" setting and n = 2**20, r = 8, p = 1
     in a "sensitive" setting.

--- a/docs/password_hashing.rst
+++ b/docs/password_hashing.rst
@@ -92,7 +92,7 @@ the message along with the salt and key derivation parameters.
     encrypted = Alices_box.encrypt(message, nonce)
 
     # now Alice must send to Bob both the encrypted message
-    # and the KDF parameters: salt, opslimit and memlimit
+    # and the KDF parameters: salt, opslimit and memlimit;
     # using the same parameters **and password**
     # Bob is able to derive the correct key to decrypt the message
 


### PR DESCRIPTION
And add a couple of missing semicolons while at it