### PR TITLE
Update encryption/decryption docstrings with optional nonces

### DIFF
--- a/docs/public.rst
+++ b/docs/public.rst
@@ -159,8 +159,9 @@ Reference
 
     .. method:: encrypt(plaintext, nonce, encoder)
 
-        Encrypts the plaintext message using the given `nonce` and returns
-        the ciphertext encoded with the encoder.
+        Encrypts the plaintext message using the given `nonce` (or generates
+        one randomly if omitted) and returns the ciphertext encoded with the
+        encoder.
 
         .. warning:: It is **VITALLY** important that the nonce is a nonce,
             i.e. it is a number used only once for any given key. If you
@@ -175,8 +176,9 @@ Reference
 
     .. method:: decrypt(ciphertext, nonce, encoder)
 
-        Decrypts the ciphertext using the given nonce and returns the
-        plaintext message.
+        Decrypts the ciphertext using the `nonce` (explicitly, when passed as a
+        parameter or implicitly, when omitted, as part of the ciphertext) and
+        returns the plaintext message.
 
         :param bytes ciphertext: The encrypted message to decrypt.
         :param bytes nonce: The nonce to use in the decryption.

--- a/docs/secret.rst
+++ b/docs/secret.rst
@@ -122,8 +122,9 @@ Reference
 
     .. method:: encrypt(plaintext, nonce, encoder)
 
-        Encrypts the plaintext message using the given nonce and returns the
-        ciphertext encoded with the encoder.
+        Encrypts the plaintext message using the given `nonce` (or generates
+        one randomly if omitted) and returns the ciphertext encoded with the
+        encoder.
 
         .. warning:: It is **VITALLY** important that the nonce is a nonce,
             i.e. it is a number used only once for any given key. If you fail
@@ -139,8 +140,9 @@ Reference
 
     .. method:: decrypt(ciphertext, nonce, encoder)
 
-        Decrypts the ciphertext using the given nonce and returns the plaintext
-        message.
+        Decrypts the ciphertext using the `nonce` (explicitly, when passed as a
+        parameter or implicitly, when omitted, as part of the ciphertext) and
+        returns the plaintext message.
 
         :param bytes ciphertext: The encrypted message to decrypt.
         :param bytes nonce: The nonce to use in the decryption.

--- a/src/nacl/public.py
+++ b/src/nacl/public.py
@@ -200,8 +200,9 @@ class Box(encoding.Encodable, StringFixer, object):
 
     def decrypt(self, ciphertext, nonce=None, encoder=encoding.RawEncoder):
         """
-        Decrypts the ciphertext using the given nonce and returns the
-        plaintext message.
+        Decrypts the ciphertext using the `nonce` (explicitly, when passed as a
+        parameter or implicitly, when omitted, as part of the ciphertext) and
+        returns the plaintext message.
 
         :param ciphertext: [:class:`bytes`] The encrypted message to decrypt
         :param nonce: [:class:`bytes`] The nonce used when encrypting the

--- a/src/nacl/secret.py
+++ b/src/nacl/secret.py
@@ -97,8 +97,9 @@ class SecretBox(encoding.Encodable, StringFixer, object):
 
     def decrypt(self, ciphertext, nonce=None, encoder=encoding.RawEncoder):
         """
-        Decrypts the ciphertext using the given nonce and returns the plaintext
-        message.
+        Decrypts the ciphertext using the `nonce` (explicitly, when passed as a
+        parameter or implicitly, when omitted, as part of the ciphertext) and
+        returns the plaintext message.
 
         :param ciphertext: [:class:`bytes`] The encrypted message to decrypt
         :param nonce: [:class:`bytes`] The nonce used when encrypting the


### PR DESCRIPTION
As discussed in #254, the `Reference` sections in the docs should also be updated with optional nonces information. I noticed that the docstrings for the `decrypt` methods did not mention that the nonces could be omitted, so I updated those as well (I hope both changes belong to this PR). Let me know what you think about the wording. Is it clear?

Thanks!