### PR TITLE
Add argon2i hashes generated via the command line

### DIFF
--- a/tests/data/modular_crypt_argon2i_hashes.json
+++ b/tests/data/modular_crypt_argon2i_hashes.json
@@ -1,0 +1,92 @@
+[
+  {
+    "passwd": "gCb0SBnpxkdLZdWe",
+    "mode": "crypt",
+    "dgst_len": 20,
+    "iters": 4,
+    "salt": "kSmmBSy5uyC4",
+    "pwhash": "$argon2i$v=19$m=131072,t=4,p=1$a1NtbUJTeTV1eUM0$gNxxt8jHCHaKDUcbdP3ugX9i+BA",
+    "maxmem": 131072
+  },
+  {
+    "passwd": "mu3KbBv3",
+    "mode": "crypt",
+    "dgst_len": 17,
+    "iters": 4,
+    "salt": "kvPMDFk4yT9sZI",
+    "pwhash": "$argon2i$v=19$m=32768,t=4,p=1$a3ZQTURGazR5VDlzWkk$V+L2XhLr+F/EevADgyfo+bM",
+    "maxmem": 32768
+  },
+  {
+    "passwd": "Bxrsg5L0A0",
+    "mode": "crypt",
+    "dgst_len": 17,
+    "iters": 3,
+    "salt": "Z5c5VUWXSJcSbr",
+    "pwhash": "$argon2i$v=19$m=65536,t=3,p=1$WjVjNVZVV1hTSmNTYnI$BqyrFpvLJUCFaf9cQAFH1Ms",
+    "maxmem": 65536
+  },
+  {
+    "passwd": "EQmTLQ2ET",
+    "mode": "crypt",
+    "dgst_len": 30,
+    "iters": 3,
+    "salt": "8aWdz2IL",
+    "pwhash": "$argon2i$v=19$m=32768,t=3,p=1$OGFXZHoySUw$U6F0Tm/c/gyjJyMi4SWjLS+8dpuiKFK0OZje6iEZ",
+    "maxmem": 32768
+  },
+  {
+    "passwd": "9wQdHVSks3tbXx",
+    "mode": "crypt",
+    "dgst_len": 19,
+    "iters": 5,
+    "salt": "HW4AgInQoU",
+    "pwhash": "$argon2i$v=19$m=65536,t=5,p=1$SFc0QWdJblFvVQ$IwHIJ6VP1vIV7xrKm+mlI1nupA",
+    "maxmem": 65536
+  },
+  {
+    "passwd": "XRGHrq53wJ1LWgV",
+    "mode": "crypt",
+    "dgst_len": 27,
+    "iters": 5,
+    "salt": "Dr57DsF3",
+    "pwhash": "$argon2i$v=19$m=131072,t=5,p=1$RHI1N0RzRjM$shLAeDv4NbeHN9Sce+jaoEHIjUTP6OnGOtZ1",
+    "maxmem": 131072
+  },
+  {
+    "passwd": "JVoDvUkiJgtm",
+    "mode": "crypt",
+    "dgst_len": 17,
+    "iters": 5,
+    "salt": "C5jzAUY8D",
+    "pwhash": "$argon2i$v=19$m=131072,t=5,p=1$QzVqekFVWThE$SqZ2XYLggynRZgYlsWFiXGI",
+    "maxmem": 131072
+  },
+  {
+    "passwd": "eZf6zOck",
+    "mode": "crypt",
+    "dgst_len": 16,
+    "iters": 3,
+    "salt": "ID0CNHQR",
+    "pwhash": "$argon2i$v=19$m=65536,t=3,p=1$SUQwQ05IUVI$ShibIsTX2z5mclt4TKyAkQ",
+    "maxmem": 65536
+  },
+  {
+    "passwd": "nPeXb5WW",
+    "mode": "crypt",
+    "dgst_len": 26,
+    "iters": 5,
+    "salt": "DibJwvJWarySIIic",
+    "pwhash": "$argon2i$v=19$m=16384,t=5,p=1$RGliSnd2SldhcnlTSUlpYw$3n/DLofidmz8LPnM925hbm+4He/iKjAlvG4",
+    "maxmem": 16384
+  },
+  {
+    "passwd": "Vgv3CCRnqkgTO2co",
+    "mode": "crypt",
+    "dgst_len": 17,
+    "iters": 5,
+    "salt": "MfmTsCzom",
+    "pwhash": "$argon2i$v=19$m=131072,t=5,p=1$TWZtVHNDem9t$1W2xtNO3w3BylGxOHuX/IZ0",
+    "maxmem": 131072
+  }
+]

--- a/tests/data/raw_argon2i_hashes.json
+++ b/tests/data/raw_argon2i_hashes.json
@@ -1,0 +1,92 @@
+[
+  {
+    "passwd": "5qflFfSWpOvQ",
+    "mode": "raw",
+    "dgst_len": 20,
+    "iters": 5,
+    "salt": "QIA9x2qmhRVmdRCU",
+    "pwhash": "3eb202f3e4b0e2c078031f724103ea526fe2a065",
+    "maxmem": 16384
+  },
+  {
+    "passwd": "pf1SMoxVb54r",
+    "mode": "raw",
+    "dgst_len": 26,
+    "iters": 4,
+    "salt": "NPBA55CsQp9wsWKy",
+    "pwhash": "b7173ea20f6eb6946d3044542fc75ef5dda0d9c94acf86d834ca",
+    "maxmem": 131072
+  },
+  {
+    "passwd": "bg9Laxjhrk8MUyhM",
+    "mode": "raw",
+    "dgst_len": 18,
+    "iters": 4,
+    "salt": "exKErRXWGdCDRSop",
+    "pwhash": "9c7957beb49f1c5e868d6a04f34d1da821f6",
+    "maxmem": 65536
+  },
+  {
+    "passwd": "n95X5vWQncMXlP",
+    "mode": "raw",
+    "dgst_len": 17,
+    "iters": 3,
+    "salt": "gxSD9VHiGF0oou1k",
+    "pwhash": "b605e0557e9f57455f246e474e93648595",
+    "maxmem": 32768
+  },
+  {
+    "passwd": "5G8iiXVYwI",
+    "mode": "raw",
+    "dgst_len": 29,
+    "iters": 4,
+    "salt": "GcjAUSZ4pLAZsDHL",
+    "pwhash": "5fa4d3b86c8ca981dbc3ea4cbbd015030bda8bd444d4039309e88b23c7",
+    "maxmem": 32768
+  },
+  {
+    "passwd": "cUu3ACKqAHnI54Eh",
+    "mode": "raw",
+    "dgst_len": 23,
+    "iters": 3,
+    "salt": "6H99IAjhJQ2WFgom",
+    "pwhash": "6202e1b58e65a658d1adcc0584fafd6373e565d6fd8348",
+    "maxmem": 32768
+  },
+  {
+    "passwd": "jBB3PBZ8v1H1aga",
+    "mode": "raw",
+    "dgst_len": 20,
+    "iters": 4,
+    "salt": "L3vcnvwJbLJTdvKx",
+    "pwhash": "f3d792b3edbf49441c269c22c2641e724cb21ef0",
+    "maxmem": 16384
+  },
+  {
+    "passwd": "WGA58n0DVW9FT",
+    "mode": "raw",
+    "dgst_len": 18,
+    "iters": 3,
+    "salt": "qN6Q3h3lzJtXcMkH",
+    "pwhash": "ec9dd7f5503cc5b74ab1fc8ac6cad426327f",
+    "maxmem": 65536
+  },
+  {
+    "passwd": "rxB2Op3fo17s6",
+    "mode": "raw",
+    "dgst_len": 27,
+    "iters": 5,
+    "salt": "xw9IrU6uf4E4hBo3",
+    "pwhash": "ffe9c857e686ab40f8758415acd6d3409acfe80d54bac24bcacfa3",
+    "maxmem": 65536
+  },
+  {
+    "passwd": "JyjdXkjHxGiGjg",
+    "mode": "raw",
+    "dgst_len": 30,
+    "iters": 5,
+    "salt": "rN0D8NoVbNBnlEex",
+    "pwhash": "fab6d8b5e1849c99f5261c15ff502b1bb245f8076efa5e01cbbdc1903512",
+    "maxmem": 32768
+  }
+]


### PR DESCRIPTION
This is a prerequisite for an upcoming PR meant to add argon2i bindings and closing #233.

@reaperhulk I don't think the python driver I've used to generate the reference data should be added in, but I'm open to any suggestion.