### PR TITLE
Correct exceptions' method resolution order

### DIFF
--- a/src/nacl/exceptions.py
+++ b/src/nacl/exceptions.py
@@ -27,19 +27,19 @@ class BadSignatureError(CryptoError):
     """
 
 
-class RuntimeError(CryptoError, RuntimeError):
+class RuntimeError(RuntimeError, CryptoError):
     pass
 
 
-class AssertionError(CryptoError, AssertionError):
+class AssertionError(AssertionError, CryptoError):
     pass
 
 
-class TypeError(CryptoError, TypeError):
+class TypeError(TypeError, CryptoError):
     pass
 
 
-class ValueError(CryptoError, ValueError):
+class ValueError(ValueError, CryptoError):
     pass
 
 


### PR DESCRIPTION
by swapping the mixed-in nacl.exception.CryptoError and the standard library parent exception in class declarations.

With this change the exceptions will "prefer" using the methods inherited from the corresponding standard library one, instead of those inherited from Exception via CryptoError.

This is not strictly needed, since we don't catch and re-raise OSError, but it feels a bit more correct. 