### PR TITLE
Break import cycle (#273)

### DIFF
--- a/src/nacl/bindings/crypto_box.py
+++ b/src/nacl/bindings/crypto_box.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import, division, print_function
 
 from nacl import exceptions as exc
 from nacl._sodium import ffi, lib
-from nacl.utils import ensure
+from nacl.exceptions import ensure
 
 
 __all__ = ["crypto_box_keypair", "crypto_box"]

--- a/src/nacl/bindings/crypto_generichash.py
+++ b/src/nacl/bindings/crypto_generichash.py
@@ -17,9 +17,9 @@ from __future__ import absolute_import, division, print_function
 from six import integer_types
 
 from nacl import exceptions as exc
-
 from nacl._sodium import ffi, lib
-from nacl.utils import ensure
+from nacl.exceptions import ensure
+
 
 crypto_generichash_BYTES = lib.crypto_generichash_blake2b_bytes()
 crypto_generichash_BYTES_MIN = lib.crypto_generichash_blake2b_bytes_min()

--- a/src/nacl/bindings/crypto_hash.py
+++ b/src/nacl/bindings/crypto_hash.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import, division, print_function
 
 from nacl import exceptions as exc
 from nacl._sodium import ffi, lib
-from nacl.utils import ensure
+from nacl.exceptions import ensure
 
 
 # crypto_hash_BYTES = lib.crypto_hash_bytes()

--- a/src/nacl/bindings/crypto_pwhash.py
+++ b/src/nacl/bindings/crypto_pwhash.py
@@ -17,7 +17,7 @@ import sys
 
 import nacl.exceptions as exc
 from nacl._sodium import ffi, lib
-from nacl.utils import ensure
+from nacl.exceptions import ensure
 
 
 crypto_pwhash_scryptsalsa208sha256_SALTBYTES = \

--- a/src/nacl/bindings/crypto_scalarmult.py
+++ b/src/nacl/bindings/crypto_scalarmult.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import, division, print_function
 
 from nacl import exceptions as exc
 from nacl._sodium import ffi, lib
-from nacl.utils import ensure
+from nacl.exceptions import ensure
 
 
 crypto_scalarmult_BYTES = lib.crypto_scalarmult_bytes()

--- a/src/nacl/bindings/crypto_secretbox.py
+++ b/src/nacl/bindings/crypto_secretbox.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import, division, print_function
 
 from nacl import exceptions as exc
 from nacl._sodium import ffi, lib
-from nacl.utils import ensure
+from nacl.exceptions import ensure
 
 
 crypto_secretbox_KEYBYTES = lib.crypto_secretbox_keybytes()

--- a/src/nacl/bindings/crypto_shorthash.py
+++ b/src/nacl/bindings/crypto_shorthash.py
@@ -15,7 +15,6 @@
 from __future__ import absolute_import, division, print_function
 
 import nacl.exceptions as exc
-from nacl import utils
 from nacl._sodium import ffi, lib
 
 BYTES = lib.crypto_shorthash_siphash24_bytes()
@@ -37,5 +36,5 @@ def crypto_shorthash_siphash24(data, key):
     digest = ffi.new("unsigned char[]", BYTES)
     rc = lib.crypto_shorthash_siphash24(digest, data, len(data), key)
 
-    utils.ensure(rc == 0, raising=exc.RuntimeError)
+    exc.ensure(rc == 0, raising=exc.RuntimeError)
     return ffi.buffer(digest, BYTES)[:]

--- a/src/nacl/bindings/crypto_sign.py
+++ b/src/nacl/bindings/crypto_sign.py
@@ -16,7 +16,7 @@ from __future__ import absolute_import, division, print_function
 
 from nacl import exceptions as exc
 from nacl._sodium import ffi, lib
-from nacl.utils import ensure
+from nacl.exceptions import ensure
 
 
 crypto_sign_BYTES = lib.crypto_sign_bytes()

--- a/src/nacl/bindings/utils.py
+++ b/src/nacl/bindings/utils.py
@@ -15,7 +15,7 @@ from __future__ import absolute_import, division, print_function
 
 import nacl.exceptions as exc
 from nacl._sodium import ffi, lib
-from nacl.utils import ensure
+from nacl.exceptions import ensure
 
 
 def sodium_memcmp(inp1, inp2):

--- a/src/nacl/exceptions.py
+++ b/src/nacl/exceptions.py
@@ -45,3 +45,24 @@ class ValueError(ValueError, CryptoError):
 
 class InvalidkeyError(CryptoError):
     pass
+
+
+def ensure(cond, *args, **kwds):
+    """
+    Return if a condition is true, otherwise raise a caller-configurable
+    :py:class:`Exception`
+    :param bool cond: the condition to be checked
+    :param sequence args: the arguments to be passed to the exception's
+                          constructor
+    The only accepted named parameter is `raising` used to configure the
+    exception to be raised if `cond` is not `True`
+    """
+    _CHK_UNEXP = 'check_condition() got an unexpected keyword argument {0}'
+
+    raising = kwds.pop('raising', AssertionError)
+    if kwds:
+        raise TypeError(_CHK_UNEXP.format(repr(kwds.popitem()[0])))
+
+    if cond is True:
+        return
+    raise raising(*args)

--- a/src/nacl/pwhash.py
+++ b/src/nacl/pwhash.py
@@ -18,7 +18,7 @@ import nacl.bindings
 import nacl.encoding
 import nacl.exceptions as exc
 
-from nacl.utils import ensure
+from nacl.exceptions import ensure
 
 _strbytes_plus_one = nacl.bindings.crypto_pwhash_scryptsalsa208sha256_STRBYTES
 

--- a/src/nacl/utils.py
+++ b/src/nacl/utils.py
@@ -17,7 +17,6 @@ from __future__ import absolute_import, division, print_function
 import six
 
 import nacl.bindings
-from nacl import exceptions as exc
 
 
 class EncryptedMessage(six.binary_type):
@@ -66,24 +65,3 @@ def bytes_as_string(bytes_in):
 
 def random(size=32):
     return nacl.bindings.randombytes(size)
-
-
-def ensure(cond, *args, **kwds):
-    """
-    Return if a condition is true, otherwise raise a caller-configurable
-    :py:class:`Exception`
-    :param bool cond: the condition to be checked
-    :param sequence args: the arguments to be passed to the exception's
-                          constructor
-    The only accepted named parameter is `raising` used to configure the
-    exception to be raised if `cond` is not `True`
-    """
-    _CHK_UNEXP = 'check_condition() got an unexpected keyword argument {0}'
-
-    raising = kwds.pop('raising', AssertionError)
-    if kwds:
-        raise exc.TypeError(_CHK_UNEXP.format(repr(kwds.popitem[0])))
-
-    if cond is True:
-        return
-    raise raising(*args)

--- a/tests/test_exc.py
+++ b/tests/test_exc.py
@@ -11,22 +11,33 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
 from __future__ import absolute_import, division, print_function
 
+import pytest
+
 from nacl import exceptions as exc
-from nacl._sodium import ffi, lib
-from nacl.exceptions import ensure
 
 
-def _sodium_init():
-    ensure(lib.sodium_init() != -1,
-           "Could not initialize sodium",
-           raising=exc.RuntimeError)
+class CustomError(exc.CryptoError):
+    pass
 
 
-def sodium_init():
-    """
-    Initializes sodium, picking the best implementations available for this
-    machine.
-    """
-    ffi.init_once(_sodium_init, "libsodium")
+def test_exceptions_ensure_with_true_condition():
+    exc.ensure(1 == 1, 'one equals one')
+
+
+def test_exceptions_ensure_with_false_condition():
+    with pytest.raises(exc.AssertionError):
+        exc.ensure(1 == 0, 'one is not zero',
+                   raising=exc.AssertionError)
+
+
+def test_exceptions_ensure_with_unwanted_kwarg():
+    with pytest.raises(exc.TypeError):
+        exc.ensure(1 == 1, unexpected='unexpected')
+
+
+def test_exceptions_ensure_custom_exception():
+    with pytest.raises(CustomError):
+        exc.ensure(1 == 0, 'Raising a CustomError', raising=CustomError)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -14,14 +14,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-import pytest
-
 import nacl.utils
-from nacl import exceptions as exc
-
-
-class CustomError(exc.CryptoError):
-    pass
 
 
 def test_random_bytes_produces():
@@ -30,23 +23,3 @@ def test_random_bytes_produces():
 
 def test_random_bytes_produces_different_bytes():
     assert nacl.utils.random(16) != nacl.utils.random(16)
-
-
-def test_util_ensure_with_true_condition():
-    nacl.utils.ensure(1 == 1, 'one equals one')
-
-
-def test_util_ensure_with_false_condition():
-    with pytest.raises(AssertionError):
-        nacl.utils.ensure(1 == 0, 'one is not zero',
-                          raising=exc.AssertionError)
-
-
-def test_util_ensure_with_unwanted_kwarg():
-    with pytest.raises(TypeError):
-        nacl.utils.ensure(1 == 1, unexpected='unexpected')
-
-
-def test_util_ensure_custom_exception():
-    with pytest.raises(CustomError):
-        nacl.utils.ensure(1 == 0, 'Raising a CustomError', raising=CustomError)


### PR DESCRIPTION
* Move ``ensure`` definition from utils to exceptions

* Use correct import for ``ensure``

* Test relocated ``ensure`` asserts replacer

* Move ``ensure`` tests to a file of their own.