### PR TITLE
Reorder link-time library search path

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -177,7 +177,7 @@ class build_ext(_build_ext):
             self.include_dirs.append(
                 os.path.join(build_clib.build_clib, "include"),
             )
-            self.library_dirs.append(
+            self.library_dirs.insert(0,
                 os.path.join(build_clib.build_clib, "lib"),
             )
 


### PR DESCRIPTION
putting bundled libsodium lib directory first.

Confirmed by submitters of #179 and #281 to fix the link errors on both freebsd and redhat 6.