### PR TITLE
Don't care about coverage in tests/

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -2,7 +2,6 @@
 branch = True
 source =
     nacl
-    tests/
 
 [paths]
 source =


### PR DESCRIPTION
It doesn't make sense to care about the coverage of the code in `tests/`, only in `nacl/`.