### PR TITLE
Add LIBSODIUM_MAKE_ARGS environment variable

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -159,14 +159,15 @@ class build_clib(_build_clib):
             cwd=build_temp,
         )
 
+        make_args = os.environ.get('LIBSODIUM_MAKE_ARGS', '').split()
         # Build the library
-        subprocess.check_call(["make"], cwd=build_temp)
+        subprocess.check_call(["make"] + make_args, cwd=build_temp)
 
         # Check the build library
-        subprocess.check_call(["make", "check"], cwd=build_temp)
+        subprocess.check_call(["make", "check"] + make_args, cwd=build_temp)
 
         # Install the built library
-        subprocess.check_call(["make", "install"], cwd=build_temp)
+        subprocess.check_call(["make", "install"] + make_args, cwd=build_temp)
 
 
 class build_ext(_build_ext):


### PR DESCRIPTION
By allowing a user to pass LIBSODIUM_MAKE_ARGS, we can decrease the compile time on slow platforms by a considerable amount.

In a `multiarch/alpine:armhf-v3.6` docker container:
* `pip install .` takes about 10 minutes
* `LIBSODIUM_MAKE_ARGS=-j4 pip install .` takes just under 4 minutes

Fixes #302