### PR TITLE
Compare and hash PrivateKey by the corresponding PublicKey

### DIFF
--- a/src/nacl/public.py
+++ b/src/nacl/public.py
@@ -92,17 +92,18 @@ class PrivateKey(encoding.Encodable, StringFixer, object):
 
         self._private_key = private_key
         self.public_key = PublicKey(raw_public_key)
+        self._hashbytes = b'p:' + bytes(self.public_key)
 
     def __bytes__(self):
         return self._private_key
 
     def __hash__(self):
-        return hash(bytes(self))
+        return hash(self._hashbytes)
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):
             return False
-        return nacl.bindings.sodium_memcmp(bytes(self), bytes(other))
+        return self.public_key == other.public_key
 
     def __ne__(self, other):
         return not (self == other)

--- a/src/nacl/public.py
+++ b/src/nacl/public.py
@@ -92,13 +92,12 @@ class PrivateKey(encoding.Encodable, StringFixer, object):
 
         self._private_key = private_key
         self.public_key = PublicKey(raw_public_key)
-        self._hashbytes = b'p:' + bytes(self.public_key)
 
     def __bytes__(self):
         return self._private_key
 
     def __hash__(self):
-        return hash(self._hashbytes)
+        return hash((type(self), bytes(self.public_key)))
 
     def __eq__(self, other):
         if not isinstance(other, self.__class__):

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -74,6 +74,16 @@ class TestPrivateKey:
         sk2 = PrivateKey(bytes(rwk2))
         return sk1, sk2
 
+    def test_equivalent_keys_have_equal_hashes(self):
+        k1, k2 = self._gen_equivalent_raw_keys_couple()
+        assert bytes(k1) != bytes(k2)
+        assert hash(k1) == hash(k2)
+
+    def test_equivalent_keys_compare_as_equal(self):
+        k1, k2 = self._gen_equivalent_raw_keys_couple()
+        assert bytes(k1) != bytes(k2)
+        assert k1 == k2
+
     def test_sk_and_pk_hashes_are_different(self):
         sk = PrivateKey(random(crypto_box_SECRETKEYBYTES))
         assert hash(sk) != hash(sk.public_key)

--- a/tests/test_public.py
+++ b/tests/test_public.py
@@ -20,6 +20,7 @@ from utils import assert_equal, assert_not_equal
 
 from nacl.bindings import crypto_box_PUBLICKEYBYTES, crypto_box_SECRETKEYBYTES
 from nacl.public import Box, PrivateKey, PublicKey
+from nacl.utils import random
 
 
 class TestPublicKey:
@@ -57,6 +58,10 @@ class TestPrivateKey:
         k2 = PrivateKey(b"\x00" * crypto_box_SECRETKEYBYTES)
         assert_equal(k1, k1)
         assert_equal(k1, k2)
+
+    def test_sk_and_pk_hashes_are_different(self):
+        sk = PrivateKey(random(crypto_box_SECRETKEYBYTES))
+        assert hash(sk) != hash(sk.public_key)
 
     @pytest.mark.parametrize('k2', [
         b"\x00" * crypto_box_SECRETKEYBYTES,


### PR DESCRIPTION
Should take comparison and hashing behavior in line with @oconnor663 expectations and solve #141 
I've put the test changes in different commits to help in verifying the difference between current and expected behavior, by verifying changes in `pytest test/test_public.py` outcomes between the commits:

- the tests introduced both in 863c3b281a842ac91906d3e0047f17a9dce9e2aa and in 9aab361fe5855d0c2d9b0ab0f9f2142047be765f will always succeed
- the tests introduced in 36b8e5a277e974f459953396d146e595c1f770aa will fail
- all the tests will succeed at 3c2348be871975fa2ef8fc7ab4de79685ba0fe01