### PR TITLE
RFC: reenable CI testing for python2.6

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ sudo: required
 
 matrix:
     include:
+        - python: 2.6
+          env: TOXENV=py26 SODIUM_INSTALL=bundled CC=gcc
         - python: 2.7
           env: TOXENV=py27 SODIUM_INSTALL=bundled CC=gcc
         - python: 3.3
@@ -52,6 +54,9 @@ matrix:
         - env: TOXENV=pypy SODIUM_INSTALL=system CC=clang
         - env: TOXENV=docs
         - env: TOXENV=meta
+    allow_failures:
+        - python: 2.6
+          env: TOXENV=py26 SODIUM_INSTALL=bundled CC=gcc
 
 install: .travis/install.sh
 


### PR DESCRIPTION
Since there are still downstream users stuck with 2.6, I'd propose to keep testing our code under 2.6 for some more time, at least until this doesn't hinder our pace.