### PR TITLE
Use the provided decoder on the nonce as well.

### DIFF
--- a/src/nacl/public.py
+++ b/src/nacl/public.py
@@ -253,6 +253,9 @@ class Box(encoding.Encodable, StringFixer, object):
             nonce = ciphertext[:self.NONCE_SIZE]
             ciphertext = ciphertext[self.NONCE_SIZE:]
 
+	# Decode our nonce
+        nonce = encoder.decode(nonce)
+
         if len(nonce) != self.NONCE_SIZE:
             raise exc.ValueError("The nonce must be exactly %s bytes long" %
                                  self.NONCE_SIZE)

--- a/src/nacl/secret.py
+++ b/src/nacl/secret.py
@@ -116,6 +116,9 @@ class SecretBox(encoding.Encodable, StringFixer, object):
             nonce = ciphertext[:self.NONCE_SIZE]
             ciphertext = ciphertext[self.NONCE_SIZE:]
 
+	# Decode our nonce
+        nonce = encoder.decode(nonce)
+
         if len(nonce) != self.NONCE_SIZE:
             raise exc.ValueError(
                 "The nonce must be exactly %s bytes long" % self.NONCE_SIZE,


### PR DESCRIPTION
HexEncoding works for the ciphertext and keys, but the nonce will throw an error if it isn't raw. This allowed decoding of the nonce same as the ciphertext.