### PR TITLE
Fix error in example

### DIFF
--- a/docs/hashing.rst
+++ b/docs/hashing.rst
@@ -30,7 +30,7 @@ Message's creator perspective (:py:func:`~nacl.hash.sha256`,
 
     # define a 1024 bytes log message
     msg = 16*b'256 BytesMessage'
-    digest = nacl.hash.HASHER(msg, encoder=nacl.encoding.HexEncoder)
+    digest = HASHER(msg, encoder=nacl.encoding.HexEncoder)
 
     # now send msg and digest to the user
     print(nacl.encoding.HexEncoder.encode(msg))


### PR DESCRIPTION
by calling the just defined function shortcut instead of a non-existent
attribute of ``nacl.hash``

This fixes an error encountered by hoang408.