### PR TITLE
drop support for python 3.3, which has low use

### DIFF
--- a/.jenkins/Jenkinsfile-pynacl-wheel-builder
+++ b/.jenkins/Jenkinsfile-pynacl-wheel-builder
@@ -1,11 +1,11 @@
 def configs = [
     [
         label: 'windows',
-        versions: ['py27', 'py33', 'py34', 'py35', 'py36'],
+        versions: ['py27', 'py34', 'py35', 'py36'],
     ],
     [
         label: 'windows64',
-        versions: ['py27', 'py33', 'py34', 'py35', 'py36'],
+        versions: ['py27', 'py34', 'py35', 'py36'],
     ],
     [
         label: 'sierra',
@@ -15,7 +15,7 @@ def configs = [
         label: 'docker',
         imageName: 'quay.io/pypa/manylinux1_x86_64',
         versions: [
-            'cp27-cp27m', 'cp27-cp27mu', 'cp33-cp33m',
+            'cp27-cp27m', 'cp27-cp27mu',
             'cp34-cp34m', 'cp35-cp35m', 'cp36-cp36m'
         ],
     ],
@@ -23,7 +23,7 @@ def configs = [
         label: 'docker',
         imageName: 'quay.io/pypa/manylinux1_i686',
         versions: [
-            'cp27-cp27m', 'cp27-cp27mu', 'cp33-cp33m',
+            'cp27-cp27m', 'cp27-cp27mu',
             'cp34-cp34m', 'cp35-cp35m', 'cp36-cp36m'
         ],
     ],
@@ -36,7 +36,6 @@ def build(version, label, imageName) {
             if (label.contains("windows")) {
                 def pythonPath = [
                     py27: "C:\\Python27\\python.exe",
-                    py33: "C:\\Python33\\python.exe",
                     py34: "C:\\Python34\\python.exe",
                     py35: "C:\\Python35\\python.exe",
                     py36: "C:\\Python36\\python.exe"

--- a/.travis.yml
+++ b/.travis.yml
@@ -8,8 +8,6 @@ matrix:
     include:
         - python: 2.7
           env: TOXENV=py27 SODIUM_INSTALL=bundled CC=gcc
-        - python: 3.3
-          env: TOXENV=py33 SODIUM_INSTALL=bundled CC=gcc
         - python: 3.4
           env: TOXENV=py34 SODIUM_INSTALL=bundled CC=gcc
         - python: 3.5
@@ -19,8 +17,6 @@ matrix:
         - env: TOXENV=pypy SODIUM_INSTALL=bundled CC=gcc
         - python: 2.7
           env: TOXENV=py27 SODIUM_INSTALL=system CC=gcc
-        - python: 3.3
-          env: TOXENV=py33 SODIUM_INSTALL=system CC=gcc
         - python: 3.4
           env: TOXENV=py34 SODIUM_INSTALL=system CC=gcc
         - python: 3.5
@@ -30,8 +26,6 @@ matrix:
         - env: TOXENV=pypy SODIUM_INSTALL=system CC=gcc
         - python: 2.7
           env: TOXENV=py27 SODIUM_INSTALL=bundled CC=clang
-        - python: 3.3
-          env: TOXENV=py33 SODIUM_INSTALL=bundled CC=clang
         - python: 3.4
           env: TOXENV=py34 SODIUM_INSTALL=bundled CC=clang
         - python: 3.5
@@ -41,8 +35,6 @@ matrix:
         - env: TOXENV=pypy SODIUM_INSTALL=bundled CC=clang
         - python: 2.7
           env: TOXENV=py27 SODIUM_INSTALL=system CC=clang
-        - python: 3.3
-          env: TOXENV=py33 SODIUM_INSTALL=system CC=clang
         - python: 3.4
           env: TOXENV=py34 SODIUM_INSTALL=system CC=clang
         - python: 3.5

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -13,6 +13,7 @@ Changelog
   the same interface for all hashers.
 * Added support for 128 bit ``siphashx24`` variant of ``siphash24``.
 * Added support for ``from_seed`` APIs for X25519 keypair generation.
+* Dropped support for Python 3.3.
 
 1.1.2 - 2017-03-31
 ------------------

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,11 +1,11 @@
 def configs = [
     [
         label: 'windows',
-        toxenvs: ['py27', 'py33', 'py34', 'py35', 'py36'],
+        toxenvs: ['py27', 'py34', 'py35', 'py36'],
     ],
     [
         label: 'windows64',
-        toxenvs: ['py27', 'py33', 'py34', 'py35', 'py36'],
+        toxenvs: ['py27', 'py34', 'py35', 'py36'],
     ],
 ]
 
@@ -46,7 +46,6 @@ def build(toxenv, label) {
             withEnv(["TOXENV=$toxenv"]) {
                 def pythonPath = [
                     py27: "C:\\Python27\\python.exe",
-                    py33: "C:\\Python33\\python.exe",
                     py34: "C:\\Python34\\python.exe",
                     py35: "C:\\Python35\\python.exe",
                     py36: "C:\\Python36\\python.exe"

--- a/README.rst
+++ b/README.rst
@@ -14,7 +14,7 @@ PyNaCl: Python binding to the libsodium library
 
 PyNaCl is a Python binding to `libsodium`_, which is a fork of the
 `Networking and Cryptography library`_. These libraries have a stated goal of
-improving usability, security and speed. It supports Python 2.7 and 3.3+ as
+improving usability, security and speed. It supports Python 2.7 and 3.4+ as
 well as PyPy 2.6+.
 
 .. _libsodium: https://github.com/jedisct1/libsodium

--- a/docs/password_hashing.rst
+++ b/docs/password_hashing.rst
@@ -53,7 +53,7 @@ internally generate a random salt, and return a hash encoded
 in ascii modular crypt format, which can be stored in a shadow-like file
 
 .. doctest::
-    :pyversion: > 3.3
+    :pyversion: >= 3.4
 
     >>> import nacl.pwhash
     >>> password = b'my password'
@@ -102,7 +102,7 @@ and operation count parameters from the modular format string
 and checks the compliance of the proposed password with the stored hash
 
 .. doctest::
-    :pyversion: > 3.3
+    :pyversion: >= 3.4
 
     >>> import nacl.pwhash
     >>> hashed = (b'$7$C6..../....qv5tF9KG2WbuMeUOa0TCoqwLHQ8s0TjQdSagne'
@@ -190,7 +190,7 @@ derivation parameters, she would derive a different key. Therefore
 the decryption would fail and an exception would be raised
 
 .. doctest::
-    :pyversion: > 3.3
+    :pyversion: >= 3.4
 
     >>> # ops, mem and salt are the same used by Alice
     ...

--- a/setup.py
+++ b/setup.py
@@ -243,7 +243,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.3",
         "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",

--- a/src/nacl/pwhash/__init__.py
+++ b/src/nacl/pwhash/__init__.py
@@ -63,7 +63,6 @@ def verify(password_hash, password):
     in the stored hash
     """
     _decoded_hash = password_hash.decode('ascii')
-    # the bytes.beginswith() method isn't supported by python 3.3
     if _decoded_hash.startswith(argon2id.STRPREFIX.decode('ascii')):
         return argon2id.verify(password_hash, password)
     elif _decoded_hash.startswith(argon2i.STRPREFIX.decode('ascii')):

--- a/src/nacl/pwhash/__init__.py
+++ b/src/nacl/pwhash/__init__.py
@@ -63,6 +63,7 @@ def verify(password_hash, password):
     in the stored hash
     """
     _decoded_hash = password_hash.decode('ascii')
+    # the bytes.beginswith() method isn't supported by python 3.3
     if _decoded_hash.startswith(argon2id.STRPREFIX.decode('ascii')):
         return argon2id.verify(password_hash, password)
     elif _decoded_hash.startswith(argon2i.STRPREFIX.decode('ascii')):


### PR DESCRIPTION
Additionally we've dropped it on other pyca projects and I'd like to not have to worry about it in our jenkins/wheel infra.