### PR TITLE
bump hypothesis requires to 3.27.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -40,7 +40,7 @@ except ImportError:
 requirements = ["six"]
 setup_requirements = []
 test_requirements = ["pytest>=3.2.1",
-                     "hypothesis>=1.11.4"]
+                     "hypothesis>=3.27.0"]
 
 
 if platform.python_implementation() == "PyPy":


### PR DESCRIPTION
hypothesis.settings.deadline was added only in 3.27.0.

Fixes: https://github.com/pyca/pynacl/issues/368
Signed-off-by: Igor Gnatenko <ignatenkobrain@fedoraproject.org>