### PR TITLE
Fix released version.

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -1,6 +1,13 @@
 Changelog
 =========
 
+1.2.1 - 2017-12-04
+------------------
+
+* Update hypothesis minumum allowed version.
+* Infrastructure: add proper configuration for readthedocs builder
+  runtime environment.
+
 1.2.0 - 2017-11-01
 ------------------
 

--- a/src/nacl/__init__.py
+++ b/src/nacl/__init__.py
@@ -24,7 +24,7 @@ __summary__ = ("Python binding to the Networking and Cryptography (NaCl) "
                "library")
 __uri__ = "https://github.com/pyca/pynacl/"
 
-__version__ = "1.2.0"
+__version__ = "1.2.1"
 
 __author__ = "The PyNaCl developers"
 __email__ = "cryptography-dev@python.org"


### PR DESCRIPTION
@reaperhulk I've provisionally set the release date as being today, but we could postpone if needed, since the problem can be simply worked around. If needed, please change the date yourself, I'm keeping the allow edits for maintainers flag enabled.

After this gets checked in and tagged, I'd like to create a 1.2.x branch and reopen development; could I just create the branch via the github GUI, or is there some other better way?