### PR TITLE
Urgent - Set readthedocs configuration from a .readthedocs.yml file in the repository

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,0 +1,5 @@
+python:
+   version: 3.5
+   pip_install: true
+   extra_requirements:
+       - docs

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -40,6 +40,9 @@ exclude .travis
 exclude .travis/install.sh
 exclude .travis/run.sh
 
+# Remove readthedocs config
+exclude .readthedocs.yml
+
 # Remove the coverage config
 exclude .coveragerc
 

--- a/setup.py
+++ b/setup.py
@@ -41,6 +41,8 @@ requirements = ["six"]
 setup_requirements = []
 test_requirements = ["pytest>=3.2.1",
                      "hypothesis>=3.27.0"]
+docs_requirements = ["sphinx>=1.6.5",
+                     "sphinx_rtd_theme"]
 
 
 if platform.python_implementation() == "PyPy":
@@ -215,6 +217,7 @@ setup(
     install_requires=requirements,
     extras_require={
         "tests": test_requirements,
+        "docs": docs_requirements,
     },
     tests_require=test_requirements,
 


### PR DESCRIPTION
This would rectify a glitch with readthedocs rendering of PyNaCl documentation, which misses our doctests, since the installed sphinx version is too old.