### PR TITLE
Add bindings to low-level ed25519 arithmetic

### DIFF
--- a/src/bindings/crypto_core.h
+++ b/src/bindings/crypto_core.h
@@ -1,4 +1,4 @@
-/* Copyright 2013 Donald Stufft and individual contributors
+/* Copyright 2017 Donald Stufft and individual contributors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -13,11 +13,11 @@
  * limitations under the License.
  */
 
-size_t crypto_scalarmult_bytes();
-size_t crypto_scalarmult_scalarbytes();
-size_t crypto_scalarmult_ed25519_bytes();
+size_t crypto_scalarmult_ed25519_scalarbytes();
+size_t crypto_core_ed25519_bytes();
+size_t crypto_core_ed25519_uniformbytes();
 
-int crypto_scalarmult_base(unsigned char *q, const unsigned char *n);
-int crypto_scalarmult(unsigned char *q, const unsigned char *n, const unsigned char *p);
-int crypto_scalarmult_ed25519(unsigned char *q, const unsigned char *n, const unsigned char *p);
-int crypto_scalarmult_ed25519_base(unsigned char *q, const unsigned char *n);
+int crypto_core_ed25519_is_valid_point(const unsigned char *p);
+int crypto_core_ed25519_from_uniform(unsigned char *p, const unsigned char *r);
+int crypto_core_ed25519_add(unsigned char *r, const unsigned char *p, const unsigned char *q);
+int crypto_core_ed25519_sub(unsigned char *r, const unsigned char *p, const unsigned char *q);

--- a/src/nacl/bindings/__init__.py
+++ b/src/nacl/bindings/__init__.py
@@ -45,6 +45,11 @@ from nacl.bindings.crypto_box import (
     crypto_box_open, crypto_box_open_afternm, crypto_box_seal,
     crypto_box_seal_open, crypto_box_seed_keypair,
 )
+from nacl.bindings.crypto_core import (
+    crypto_core_ed25519_BYTES, crypto_core_ed25519_UNIFORMBYTES,
+    crypto_core_ed25519_add, crypto_core_ed25519_from_uniform,
+    crypto_core_ed25519_is_valid_point, crypto_core_ed25519_sub
+)
 from nacl.bindings.crypto_generichash import (
     crypto_generichash_BYTES, crypto_generichash_BYTES_MAX,
     crypto_generichash_BYTES_MIN, crypto_generichash_KEYBYTES,
@@ -119,7 +124,9 @@ from nacl.bindings.crypto_pwhash import (
 )
 from nacl.bindings.crypto_scalarmult import (
     crypto_scalarmult, crypto_scalarmult_BYTES, crypto_scalarmult_SCALARBYTES,
-    crypto_scalarmult_base
+    crypto_scalarmult_base, crypto_scalarmult_ed25519,
+    crypto_scalarmult_ed25519_BYTES, crypto_scalarmult_ed25519_SCALARBYTES,
+    crypto_scalarmult_ed25519_base
 )
 from nacl.bindings.crypto_secretbox import (
     crypto_secretbox, crypto_secretbox_BOXZEROBYTES, crypto_secretbox_KEYBYTES,
@@ -188,6 +195,13 @@ __all__ = [
     "crypto_box_seal_open",
     "crypto_box_seed_keypair",
 
+    "crypto_core_ed25519_BYTES",
+    "crypto_core_ed25519_UNIFORMBYTES",
+    "crypto_core_ed25519_add",
+    "crypto_core_ed25519_from_uniform",
+    "crypto_core_ed25519_is_valid_point",
+    "crypto_core_ed25519_sub",
+
     "crypto_hash_BYTES",
     "crypto_hash_sha256_BYTES",
     "crypto_hash_sha512_BYTES",
@@ -214,6 +228,10 @@ __all__ = [
     "crypto_scalarmult_SCALARBYTES",
     "crypto_scalarmult",
     "crypto_scalarmult_base",
+    "crypto_scalarmult_ed25519_BYTES",
+    "crypto_scalarmult_ed25519_SCALARBYTES",
+    "crypto_scalarmult_ed25519",
+    "crypto_scalarmult_ed25519_base",
 
     "crypto_secretbox_KEYBYTES",
     "crypto_secretbox_NONCEBYTES",

--- a/src/nacl/bindings/crypto_core.py
+++ b/src/nacl/bindings/crypto_core.py
@@ -1,0 +1,75 @@
+# Copyright 2013 Donald Stufft and individual contributors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from __future__ import absolute_import, division, print_function
+
+from nacl import exceptions as exc
+from nacl._sodium import ffi, lib
+from nacl.exceptions import ensure
+
+
+crypto_core_ed25519_BYTES = lib.crypto_core_ed25519_bytes()
+crypto_core_ed25519_UNIFORMBYTES = lib.crypto_core_ed25519_uniformbytes()
+
+
+def crypto_core_ed25519_is_valid_point(p):
+    """
+    Checks if ``p`` represents a point on the edwards25519 curve, in canonical
+    form, on the main subgroup, and that the point doesn't have a small order.
+    """
+    rc = lib.crypto_core_ed25519_is_valid_point(p)
+    return rc == 1
+
+
+def crypto_core_ed25519_from_uniform(r):
+    """
+    Maps a 32 bytes vector (usually the output of a hash function) to a point
+    on the edwards25519 curve in compressed representation.
+    """
+    p = ffi.new("unsigned char[]", crypto_core_ed25519_BYTES)
+
+    rc = lib.crypto_core_ed25519_from_uniform(p, r)
+    ensure(rc == 0,
+           'Unexpected library error',
+           raising=exc.RuntimeError)
+
+    return ffi.buffer(p, crypto_core_ed25519_BYTES)[:]
+
+
+def crypto_core_ed25519_add(p, q):
+    """
+    Adds two points on the edwards25519 curve.
+    """
+    r = ffi.new("unsigned char[]", crypto_core_ed25519_BYTES)
+
+    rc = lib.crypto_core_ed25519_add(r, p, q)
+    ensure(rc == 0,
+           'Unexpected library error',
+           raising=exc.RuntimeError)
+
+    return ffi.buffer(r, crypto_core_ed25519_BYTES)[:]
+
+
+def crypto_core_ed25519_sub(p, q):
+    """
+    Adds two points on the edwards25519 curve.
+    """
+    r = ffi.new("unsigned char[]", crypto_core_ed25519_BYTES)
+
+    rc = lib.crypto_core_ed25519_sub(r, p, q)
+    ensure(rc == 0,
+           'Unexpected library error',
+           raising=exc.RuntimeError)
+
+    return ffi.buffer(r, crypto_core_ed25519_BYTES)[:]

--- a/src/nacl/bindings/crypto_scalarmult.py
+++ b/src/nacl/bindings/crypto_scalarmult.py
@@ -21,6 +21,9 @@ from nacl.exceptions import ensure
 
 crypto_scalarmult_BYTES = lib.crypto_scalarmult_bytes()
 crypto_scalarmult_SCALARBYTES = lib.crypto_scalarmult_scalarbytes()
+crypto_scalarmult_ed25519_BYTES = lib.crypto_scalarmult_ed25519_bytes()
+crypto_scalarmult_ed25519_SCALARBYTES = \
+    lib.crypto_scalarmult_ed25519_scalarbytes()
 
 
 def crypto_scalarmult_base(n):
@@ -58,3 +61,40 @@ def crypto_scalarmult(n, p):
            raising=exc.RuntimeError)
 
     return ffi.buffer(q, crypto_scalarmult_SCALARBYTES)[:]
+
+
+def crypto_scalarmult_ed25519_base(n):
+    """
+    Computes and returns the scalar product of a standard group element and an
+    integer ``n`` on the edwards25519 curve.
+
+    :param n: bytes
+    :rtype: bytes
+    """
+    q = ffi.new("unsigned char[]", crypto_scalarmult_ed25519_BYTES)
+
+    rc = lib.crypto_scalarmult_ed25519_base(q, n)
+    ensure(rc == 0,
+           'Unexpected library error',
+           raising=exc.RuntimeError)
+
+    return ffi.buffer(q, crypto_scalarmult_ed25519_SCALARBYTES)[:]
+
+
+def crypto_scalarmult_ed25519(n, p):
+    """
+    Computes and returns the scalar product of the given group element and an
+    integer ``n`` on the edwards25519 curve.
+
+    :param p: bytes
+    :param n: bytes
+    :rtype: bytes
+    """
+    q = ffi.new("unsigned char[]", crypto_scalarmult_ed25519_BYTES)
+
+    rc = lib.crypto_scalarmult_ed25519(q, n, p)
+    ensure(rc == 0,
+           'Unexpected library error',
+           raising=exc.RuntimeError)
+
+    return ffi.buffer(q, crypto_scalarmult_ed25519_SCALARBYTES)[:]

--- a/src/nacl/bindings/crypto_secretbox.py
+++ b/src/nacl/bindings/crypto_secretbox.py
@@ -22,7 +22,8 @@ from nacl.exceptions import ensure
 crypto_secretbox_KEYBYTES = lib.crypto_secretbox_keybytes()
 crypto_secretbox_NONCEBYTES = lib.crypto_secretbox_noncebytes()
 crypto_secretbox_ZEROBYTES = lib.crypto_secretbox_zerobytes()
-crypto_secretbox_BOXZEROBYTES = lib.crypto_secretbox_boxzerobytes()
+crypto_secretbox_BOXZEROBYTES = \
+    lib.crypto_secretbox_boxzerobytes()
 
 
 def crypto_secretbox(message, nonce, key):


### PR DESCRIPTION
This PR should be merged after #407 (i can rebase when it is so only the second commit is left to merge here). It adds bindings in `nacl.bindings` to the new functions and symbols (`crypto_scalarmult_ed25519_*` and `crypto_core_ed25519_*`).