### PR TITLE
Allow tests/test_pwhash.py deadlines to be adjusted

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,6 +12,9 @@ Changelog
   on fixed-precision big integers represented as little-endian
   byte sequences.
 * Add low-level bindings for the ISO/IEC 7816-4 compatible padding API.
+* Add PYNACL_HYPOTHESIS_DEADLINE environment variable to allow the allowed
+  time for tests in tests/test_pwhash.py to be adjusted for slower processor
+  architectures.  GitHub issue #370
 
 1.2.1 - 2017-12-04
 ------------------

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -12,9 +12,9 @@ Changelog
   on fixed-precision big integers represented as little-endian
   byte sequences.
 * Add low-level bindings for the ISO/IEC 7816-4 compatible padding API.
-* Add PYNACL_HYPOTHESIS_DEADLINE environment variable to allow the allowed
-  time for tests in tests/test_pwhash.py to be adjusted for slower processor
-  architectures.  GitHub issue #370
+* Set hypothesis deadline to None in tests/test_pwhash.py to avoid
+  incorrect test failures on slower processor architectures.  GitHub 
+  issue #370
 
 1.2.1 - 2017-12-04
 ------------------

--- a/tests/test_pwhash.py
+++ b/tests/test_pwhash.py
@@ -32,11 +32,6 @@ import nacl.encoding
 import nacl.exceptions as exc
 import nacl.pwhash
 
-_deadline = os.getenv('PYNACL_HYPOTHESIS_DEADLINE', 1500)
-# Set the environment variable PYNACL_HYPOTHESIS_DEADLINE to an
-# appropriate value for the architecture under test before running tests.
-# 1,500 milliseconds is the default for fast architectures like amd64.
-
 _all_unicode = u''.join(unichr(i) for i in range(sys.maxunicode))
 PASSWD_CHARS = u''.join(c for c in _all_unicode
                         if (ud.category(c).startswith('L') or
@@ -415,7 +410,7 @@ def test_str_verify_argon2_ref_fail(password_hash, password):
        integers(min_value=1024 * 1024,
                 max_value=16 * 1024 * 1024)
        )
-@settings(deadline=_deadline, max_examples=20, timeout=unlimited)
+@settings(deadline=None, max_examples=20, timeout=unlimited)
 def test_argon2i_str_and_verify(password, ops, mem):
     _psw = password.encode('utf-8')
     pw_hash = nacl.pwhash.argon2i.str(_psw, opslimit=ops, memlimit=mem)
@@ -429,7 +424,7 @@ def test_argon2i_str_and_verify(password, ops, mem):
        integers(min_value=1024 * 1024,
                 max_value=16 * 1024 * 1024)
        )
-@settings(deadline=_deadline, max_examples=20, timeout=unlimited)
+@settings(deadline=None, max_examples=20, timeout=unlimited)
 def test_argon2id_str_and_verify(password, ops, mem):
     _psw = password.encode('utf-8')
     pw_hash = nacl.pwhash.argon2id.str(_psw, opslimit=ops, memlimit=mem)
@@ -443,7 +438,7 @@ def test_argon2id_str_and_verify(password, ops, mem):
        integers(min_value=1024 * 1024,
                 max_value=16 * 1024 * 1024)
        )
-@settings(deadline=_deadline, max_examples=20, timeout=unlimited)
+@settings(deadline=None, max_examples=20, timeout=unlimited)
 def test_argon2i_str_and_verify_fail(password, ops, mem):
     _psw = password.encode('utf-8')
     pw_hash = nacl.pwhash.argon2i.str(_psw, opslimit=ops, memlimit=mem)
@@ -452,7 +447,7 @@ def test_argon2i_str_and_verify_fail(password, ops, mem):
 
 
 @given(text(alphabet=PASSWD_CHARS, min_size=5, max_size=20))
-@settings(deadline=_deadline, max_examples=5, timeout=unlimited)
+@settings(deadline=None, max_examples=5, timeout=unlimited)
 def test_pwhash_str_and_verify(password):
     _psw = password.encode('utf-8')
 

--- a/tests/test_pwhash.py
+++ b/tests/test_pwhash.py
@@ -32,6 +32,10 @@ import nacl.encoding
 import nacl.exceptions as exc
 import nacl.pwhash
 
+_deadline = os.getenv('PYNACL_HYPOTHESIS_DEADLINE', 1500)
+# Set the environment variable PYNACL_HYPOTHESIS_DEADLINE to an
+# appropriate value for the architecture under test before running tests.
+# 1,500 milliseconds is the default for fast architectures like amd64.
 
 _all_unicode = u''.join(unichr(i) for i in range(sys.maxunicode))
 PASSWD_CHARS = u''.join(c for c in _all_unicode
@@ -411,7 +415,7 @@ def test_str_verify_argon2_ref_fail(password_hash, password):
        integers(min_value=1024 * 1024,
                 max_value=16 * 1024 * 1024)
        )
-@settings(deadline=1500, max_examples=20, timeout=unlimited)
+@settings(deadline=_deadline, max_examples=20, timeout=unlimited)
 def test_argon2i_str_and_verify(password, ops, mem):
     _psw = password.encode('utf-8')
     pw_hash = nacl.pwhash.argon2i.str(_psw, opslimit=ops, memlimit=mem)
@@ -425,7 +429,7 @@ def test_argon2i_str_and_verify(password, ops, mem):
        integers(min_value=1024 * 1024,
                 max_value=16 * 1024 * 1024)
        )
-@settings(deadline=1500, max_examples=20, timeout=unlimited)
+@settings(deadline=_deadline, max_examples=20, timeout=unlimited)
 def test_argon2id_str_and_verify(password, ops, mem):
     _psw = password.encode('utf-8')
     pw_hash = nacl.pwhash.argon2id.str(_psw, opslimit=ops, memlimit=mem)
@@ -439,7 +443,7 @@ def test_argon2id_str_and_verify(password, ops, mem):
        integers(min_value=1024 * 1024,
                 max_value=16 * 1024 * 1024)
        )
-@settings(deadline=1500, max_examples=20, timeout=unlimited)
+@settings(deadline=_deadline, max_examples=20, timeout=unlimited)
 def test_argon2i_str_and_verify_fail(password, ops, mem):
     _psw = password.encode('utf-8')
     pw_hash = nacl.pwhash.argon2i.str(_psw, opslimit=ops, memlimit=mem)
@@ -448,7 +452,7 @@ def test_argon2i_str_and_verify_fail(password, ops, mem):
 
 
 @given(text(alphabet=PASSWD_CHARS, min_size=5, max_size=20))
-@settings(deadline=1500, max_examples=5, timeout=unlimited)
+@settings(deadline=_deadline, max_examples=5, timeout=unlimited)
 def test_pwhash_str_and_verify(password):
     _psw = password.encode('utf-8')
 


### PR DESCRIPTION
For anyone who doesn't care (and thus doesn't set the new environment variable), this change is a no-op.  I've verified the tests all run and pass on both python2.7 and python3.6.

For those that do care (in my case as a Debian package maintainer) we can set the environment variable on a per-architecture basis to allow more time for slower processors.

This should address https://github.com/pyca/pynacl/issues/370 .  Fedora should be able to turn the same knob as needed to address their slow builders.