### PR TITLE
Also insert build-local lib64 directory in linker search path.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -191,6 +191,9 @@ class build_ext(_build_ext):
                 os.path.join(build_clib.build_clib, "include"),
             )
             self.library_dirs.insert(0,
+                os.path.join(build_clib.build_clib, "lib64"),
+            )
+            self.library_dirs.insert(0,
                 os.path.join(build_clib.build_clib, "lib"),
             )
 


### PR DESCRIPTION
At least in a opensuse42.3 build environment, setup.py install the bundled library in a "lib64" subdirectory, that wasn't present in the linker search path. Should complete #282 and at least solve the problem lamented by @guidow in #406.