### PR TITLE
Include license file in the generated wheel package

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[metadata]
+license_file = LICENSE


### PR DESCRIPTION
The wheel package format supports including the license file. This is done using the `[metadata]` section in the `setup.cfg` file. For additional information on this feature, see:

https://wheel.readthedocs.io/en/stable/index.html#including-the-license-in-the-generated-wheel-file

Helps project comply with its own license:

> You must give any other recipients of the Work or Derivative Works a copy of this License;