### PR TITLE
stop codecov from commenting on PRs

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -46,6 +46,9 @@ exclude .readthedocs.yml
 # Remove the coverage config
 exclude .coveragerc
 
+# exclude codecov
+exclude codecov.yml
+
 # Remove release automation script
 exclude tasks.py
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,9 @@
+comment: false
+coverage:
+    status:
+        patch:
+            default:
+                target: '100'
+        project:
+            default:
+                target: '100'


### PR DESCRIPTION
we already require 100% coverage, it can just fail the status check