### PR TITLE
Update pypi.python.org URL to pypi.org

### DIFF
--- a/tasks.py
+++ b/tasks.py
@@ -113,7 +113,7 @@ def release(ctx, version):
     # so that the Jenkins builders will see the new sdist immediately when they
     # go to build the wheels.
     response = session.request(
-        "PURGE", "https://pypi.python.org/simple/pynacl/"
+        "PURGE", "https://pypi.org/simple/pynacl/"
     )
     response.raise_for_status()
 


### PR DESCRIPTION
For details on the new PyPI, see the blog post:

https://pythoninsider.blogspot.ca/2018/04/new-pypi-launched-legacy-pypi-shutting.html