### PR TITLE
Drop EOL Python 2.6 & 3.3 from tox.ini

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py26,py27,pypy,py33,py34,py35,py36,py37,docs,meta
+envlist = py27,pypy,py34,py35,py36,py37,docs,meta
 
 [testenv]
 extras =


### PR DESCRIPTION
Python 2.6 support was removed in 42ef7df6a886596834c626b3cf0a4f9a6459f9f3, version 1.1.0.

Python 3.3 support was removed in 1612d7e76076242f496de5bac9045ca6233d4424, version 1.2.0.