### PR TITLE
Replace use of six.binary_type with bytes

### DIFF
--- a/src/nacl/signing.py
+++ b/src/nacl/signing.py
@@ -14,8 +14,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-import six
-
 import nacl.bindings
 from nacl import encoding
 from nacl import exceptions as exc
@@ -24,7 +22,7 @@ from nacl.public import (PrivateKey as _Curve25519_PrivateKey,
 from nacl.utils import StringFixer, random
 
 
-class SignedMessage(six.binary_type):
+class SignedMessage(bytes):
     """
     A bytes subclass that holds a messaged that has been signed by a
     :class:`SigningKey`.

--- a/src/nacl/utils.py
+++ b/src/nacl/utils.py
@@ -19,7 +19,7 @@ import os
 import six
 
 
-class EncryptedMessage(six.binary_type):
+class EncryptedMessage(bytes):
     """
     A bytes subclass that holds a messaged that has been encrypted by a
     :class:`SecretBox`.


### PR DESCRIPTION
The type `bytes` exists on all supported Pythons. On Python 2, it is an
alias of `str`, same as six. There is no need to use a compatibility shim.
Makes code more forward compatible with Python 3 idioms.