### PR TITLE
Remove average_size hypothesis setting from test_bindings.py

### DIFF
--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -306,7 +306,6 @@ def test_unpad_not_padded():
 
 
 @given(binary(min_size=0,
-              average_size=128,
               max_size=2049),
        integers(min_value=16,
                 max_value=256)
@@ -320,7 +319,6 @@ def test_pad_sizes(msg, bl_sz):
 
 
 @given(binary(min_size=0,
-              average_size=128,
               max_size=2049),
        integers(min_value=16,
                 max_value=256)


### PR DESCRIPTION
Hypothesis puts out the following when I build pynacl 1.3.0:

`HypothesisDeprecationWarning: You should remove the average_size argument, because it is deprecated and no longer has any effect.  Please open an issue if the default distribution of examples does not work for you.`

This PR removes `average_size` from `test_bindings.py`, which is the only occurrence of that setting I could find.

The deprecation announcement can also be found in the [Hypothesis changelog](https://hypothesis.readthedocs.io/en/latest/changes.html#v3-51-0) for version 3.51.0 released on 2018-03-24.
I'm not an expert in Hypothesis but since it says that `average_size` doesn't have any effect anymore, it should be safe to remove.