### PR TITLE
Allow very slow execution of test_crypto_kx_seed_keypair_seed_too_large

### DIFF
--- a/tests/test_kx.py
+++ b/tests/test_kx.py
@@ -14,7 +14,7 @@
 
 from __future__ import absolute_import, division, print_function
 
-from hypothesis import given, settings
+from hypothesis import given, settings, HealthCheck
 from hypothesis.strategies import binary
 
 import pytest
@@ -48,7 +48,9 @@ def test_crypto_kx_seed_keypair(seed1, seed2):
 @given(binary(min_size=33,
               max_size=128),
        )
-@settings(max_examples=20)
+@settings(max_examples=20, suppress_health_check=[
+    HealthCheck.too_slow
+])
 def test_crypto_kx_seed_keypair_seed_too_large(seed):
     with pytest.raises(exc.TypeError):
         b.crypto_kx_seed_keypair(seed)


### PR DESCRIPTION
I pushed pynacl 1.3.0 to [Nixpkgs](https://github.com/NixOS/nixpkgs/) yesterday and a very slow build of it failed (build took 7m 17s, tests took 366.73 seconds).

`E   FailedHealthCheck: Data generation is extremely slow: Only produced 9 valid examples in 1.09 seconds (0 invalid ones and 0 exceeded maximum size). Try decreasing size of the data you're generating (with e.g.max_size or max_leaves parameters).
E   See https://hypothesis.readthedocs.io/en/latest/healthchecks.html for more information about this. If you want to disable just this health check, add HealthCheck.too_slow to the suppress_health_check settings for this test.
tests/test_kx.py:49: FailedHealthCheck`

We've had a similar problem before with deadlines and timeouts in other tests. Those were deactivated or set to unlimited in #411 and #422 because tests failing due to exceeding certain time limits make using pynacl on slow devices harder.
This PR adds `HealthCheck.too_slow` in a `suppress_health_check` setting to `test_crypto_kx_seed_keypair_seed_too_large` in `test_kx.py` as the error suggests.
If you'd rather decrease the `max_size` setting for that particular test or pursue a different solution, feel free to let me know :)