### PR TITLE
Fix crypto_kx bindings tests for slow archs

### DIFF
--- a/tests/test_kx.py
+++ b/tests/test_kx.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import, division, print_function
 
 from hypothesis import given, settings
 from hypothesis.strategies import binary
+from hypothesis import HealthCheck
 
 import pytest
 
@@ -48,7 +49,7 @@ def test_crypto_kx_seed_keypair(seed1, seed2):
 @given(binary(min_size=33,
               max_size=128),
        )
-@settings(max_examples=20)
+@settings(suppress_health_check=[HealthCheck.too_slow],max_examples=20)
 def test_crypto_kx_seed_keypair_seed_too_large(seed):
     with pytest.raises(exc.TypeError):
         b.crypto_kx_seed_keypair(seed)


### PR DESCRIPTION
Cancel hypothesis too_slow health check for test_crypto_kx_seed_keypair_seed_too_large to fix build on very slow architectures such mips.  On Debian this test failed due to HealthCheck.too_slow on mips, mipsel, mips64el, sparc64, and riscv64.  With the change, all pass.  The error was:

=================================== FAILURES ===================================
__________________ test_crypto_kx_seed_keypair_seed_too_large __________________

    @given(binary(min_size=33,
                 max_size=128),
           )
    @settings(max_examples=20)
    def test_crypto_kx_seed_keypair_seed_too_large(seed):
E   hypothesis.errors.FailedHealthCheck: Data generation is extremely slow: Only produced 9 valid examples in 1.07 seconds (0 invalid ones and 0 exceeded maximum size). Try decreasing size of the data you're generating (with e.g.max_size or max_leaves parameters).
E   See https://hypothesis.readthedocs.io/en/latest/healthchecks.html for more information about this. If you want to disable just this health check, add HealthCheck.too_slow to the suppress_health_check settings for this test.

../../../tests/test_kx.py:49: FailedHealthCheck

Even on slow architectures, disabling this check should only increase the test duration by a few seconds.