### PR TITLE
Signature encoders

### DIFF
--- a/docs/public.rst
+++ b/docs/public.rst
@@ -219,7 +219,7 @@ Reference
 
         :return: An instance of :class:`~nacl.public.Box`.
 
-    .. method:: encrypt(plaintext, nonce, encoder)
+    .. method:: encrypt(plaintext, nonce, ciphertext_encoder, nonce_encoder)
 
         Encrypts the plaintext message using the given `nonce` (or generates
         one randomly if omitted) and returns the ciphertext encoded with the
@@ -232,11 +232,12 @@ Reference
 
         :param bytes plaintext: The plaintext message to encrypt.
         :param bytes nonce: The nonce to use in the encryption.
-        :param encoder:  A class that is able to decode the ciphertext.
+        :param ciphertext_encoder: The encoder to use to encode the ciphertext.
+        :param nonce_encoder: The encoder to use to encode the nonce.
 
         :return: An instance of :class:`~nacl.utils.EncryptedMessage`.
 
-    .. method:: decrypt(ciphertext, nonce, encoder)
+    .. method:: decrypt(ciphertext, nonce, ciphertext_encoder, nonce_encoder)
 
         Decrypts the ciphertext using the `nonce` (explicitly, when passed as a
         parameter or implicitly, when omitted, as part of the ciphertext) and
@@ -244,7 +245,8 @@ Reference
 
         :param bytes ciphertext: The encrypted message to decrypt.
         :param bytes nonce: The nonce to use in the decryption.
-        :param encoder: A class that is able to decode the plaintext.
+        :param ciphertext_encoder: The encoder to use to decode the ciphertext.
+        :param nonce_encoder: The encoder to use to decode the nonce.
 
         :return bytes: The decrypted plaintext.
 

--- a/docs/secret.rst
+++ b/docs/secret.rst
@@ -148,7 +148,7 @@ Reference
     :param bytes key: The secret key used to encrypt and decrypt messages.
     :param encoder: A class that is able to decode the ``key``.
 
-    .. method:: encrypt(plaintext, nonce, encoder)
+    .. method:: encrypt(plaintext, nonce, ciphertext_encoder, nonce_encoder)
 
         Encrypts the plaintext message using the given `nonce` (or generates
         one randomly if omitted) and returns the ciphertext encoded with the
@@ -162,7 +162,8 @@ Reference
 
         :param bytes plaintext: The plaintext message to encrypt.
         :param bytes nonce: The nonce to use in the encryption.
-        :param encoder:  A class that is able to decode the ciphertext.
+        :param ciphertext_encoder: The encoder to use to encode the ciphertext.
+        :param nonce_encoder: The encoder to use to encode the nonce.
 
         :return: An instance of :class:`~nacl.utils.EncryptedMessage`.
 
@@ -174,7 +175,8 @@ Reference
 
         :param bytes ciphertext: The encrypted message to decrypt.
         :param bytes nonce: The nonce to use in the decryption.
-        :param encoder: A class that is able to decode the plaintext.
+        :param ciphertext_encoder: The encoder to use to decode the ciphertext.
+        :param nonce_encoder: The encoder to use to decode the nonce.
 
         :return bytes: The decrypted plaintext.
 

--- a/docs/signing.rst
+++ b/docs/signing.rst
@@ -82,7 +82,9 @@ Signer's perspective (:class:`~nacl.signing.SigningKey`)
     signing_key = SigningKey.generate()
 
     # Sign a message with the signing key
-    signed_hex = signing_key.sign(b"Attack at Dawn", encoder=HexEncoder)
+    signed_hex = signing_key.sign(b"Attack at Dawn",
+                                  message_encoder=HexEncoder,
+                                  signature_encoder=HexEncoder)
 
     # Obtain the verify key for a given signing key
     verify_key = signing_key.verify_key
@@ -104,10 +106,9 @@ Verifier's perspective (:class:`~nacl.signing.VerifyKey`)
     # The message and the signature can either be passed together, or
     # separately if the signature is decoded to raw bytes.
     # These are equivalent:
-    verify_key.verify(signed_hex, encoder=HexEncoder)
-    signature_bytes = HexEncoder.decode(signed_hex.signature)
-    verify_key.verify(signed_hex.message, signature_bytes,
-                      encoder=HexEncoder)
+    verify_key.verify(signed_hex, message_encoder=HexEncoder)
+    verify_key.verify(signed_hex.message, signed_hex.signature,
+                      message_encoder=HexEncoder, signature_encoder=HexEncoder)
 
     # Alter the signed message text
     forged = signed_hex[:-1] + bytes([int(signed_hex[-1]) ^ 1])
@@ -138,7 +139,9 @@ Signer's perspective (:class:`~nacl.signing.SigningKey`)
     signing_key = SigningKey.generate()
 
     # Sign a message with the signing key
-    signed_b64 = signing_key.sign(b"Attack at Dawn", encoder=Base64Encoder)
+    signed_b64 = signing_key.sign(b"Attack at Dawn",
+                                  message_encoder=Base64Encoder,
+                                  signature_encoder=Base64Encoder)
 
     # Obtain the verify key for a given signing key
     verify_key = signing_key.verify_key
@@ -160,10 +163,10 @@ Verifier's perspective (:class:`~nacl.signing.VerifyKey`)
     # The message and the signature can either be passed together, or
     # separately if the signature is decoded to raw bytes.
     # These are equivalent:
-    verify_key.verify(signed_b64, encoder=Base64Encoder)
-    signature_bytes = Base64Encoder.decode(signed_b64.signature)
-    verify_key.verify(signed_b64.message, signature_bytes,
-                      encoder=Base64Encoder)
+    verify_key.verify(signed_b64, message_encoder=Base64Encoder)
+    verify_key.verify(signed_b64.message, signed_b64.signature,
+                      message_encoder=Base64Encoder,
+                      signature_encoder=Base64Encoder)
 
     # Alter the signed message text
     forged = signed_b64[:-1] + bytes([int(signed_b64[-1]) ^ 1])
@@ -207,12 +210,13 @@ Reference
 
         :return: An instance of :class:`~nacl.signing.SigningKey`.
 
-    .. method:: sign(message, encoder)
+    .. method:: sign(message, message_encoder, signature_encoder)
 
         Sign a message using this key.
 
         :param bytes message: The data to be signed.
-        :param encoder: A class that is able to encode the signed message.
+        :param message_encoder: A class that is able to decode the signed message.
+        :param signature_encoder: A class that is able to decode the signed signature.
 
         :return: An instance of :class:`~nacl.signing.SignedMessage`.
 
@@ -224,7 +228,7 @@ Reference
     :param bytes key: A serialized Ed25519 public key.
     :param encoder: A class that is able to decode the ``key``.
 
-    .. method:: verify(smessage, signature, encoder)
+    .. method:: verify(smessage, signature, message_encoder, signature_encoder)
 
         Verifies the signature of a signed message.
 
@@ -233,8 +237,8 @@ Reference
         :param bytes signature: The signature of the message to verify against.
             If the value of ``smessage`` is the concated signature and message,
             this parameter can be ``None``.
-        :param encoder: A class that is able to decode the secret message and
-            signature.
+        :param message_encoder: A class that is able to decode the message.
+        :param signature_encoder: A class that is able to decode the signature.
 
         :return bytes: The message if successfully verified.
 

--- a/docs/signing.rst
+++ b/docs/signing.rst
@@ -212,7 +212,7 @@ Reference
         Sign a message using this key.
 
         :param bytes message: The data to be signed.
-        :param encoder: A class that is able to decode the signed message.
+        :param encoder: A class that is able to encode the signed message.
 
         :return: An instance of :class:`~nacl.signing.SignedMessage`.
 

--- a/src/nacl/secret.py
+++ b/src/nacl/secret.py
@@ -14,6 +14,8 @@
 
 from __future__ import absolute_import, division, print_function
 
+import warnings
+
 import nacl.bindings
 from nacl import encoding
 from nacl import exceptions as exc
@@ -65,7 +67,9 @@ class SecretBox(encoding.Encodable, StringFixer, object):
     def __bytes__(self):
         return self._key
 
-    def encrypt(self, plaintext, nonce=None, encoder=encoding.RawEncoder):
+    def encrypt(self, plaintext, nonce=None, encoder=None,
+                ciphertext_encoder=encoding.RawEncoder,
+                nonce_encoder=encoding.RawEncoder):
         """
         Encrypts the plaintext message using the given `nonce` (or generates
         one randomly if omitted) and returns the ciphertext encoded with the
@@ -79,9 +83,18 @@ class SecretBox(encoding.Encodable, StringFixer, object):
 
         :param plaintext: [:class:`bytes`] The plaintext message to encrypt
         :param nonce: [:class:`bytes`] The nonce to use in the encryption
-        :param encoder: The encoder to use to encode the ciphertext
+        :param encoder: DEPRECATED: The encoder to use to encode the ciphertext
+        :param ciphertext_encoder: The encoder to use to encode the ciphertext
+        :param nonce_encoder: The encoder to use to encode the nonce
         :rtype: [:class:`nacl.utils.EncryptedMessage`]
         """
+        if encoder is not None:
+            warnings.warn("Use of encoder is deprecated. Please update your "
+                          "code to use ciphertext_encoder and nonce_encoder "
+                          "instead.",
+                          DeprecationWarning)
+            ciphertext_encoder = encoder
+
         if nonce is None:
             nonce = random(self.NONCE_SIZE)
 
@@ -93,16 +106,18 @@ class SecretBox(encoding.Encodable, StringFixer, object):
         ciphertext = nacl.bindings.crypto_secretbox(plaintext,
                                                     nonce, self._key)
 
-        encoded_nonce = encoder.encode(nonce)
-        encoded_ciphertext = encoder.encode(ciphertext)
+        encoded_nonce = nonce_encoder.encode(nonce)
+        encoded_ciphertext = ciphertext_encoder.encode(ciphertext)
 
         return EncryptedMessage._from_parts(
             encoded_nonce,
             encoded_ciphertext,
-            encoder.encode(nonce + ciphertext),
+            ciphertext_encoder.encode(nonce + ciphertext),
         )
 
-    def decrypt(self, ciphertext, nonce=None, encoder=encoding.RawEncoder):
+    def decrypt(self, ciphertext, nonce=None, encoder=None,
+                ciphertext_encoder=encoding.RawEncoder,
+                nonce_encoder=encoding.RawEncoder):
         """
         Decrypts the ciphertext using the `nonce` (explicitly, when passed as a
         parameter or implicitly, when omitted, as part of the ciphertext) and
@@ -111,11 +126,23 @@ class SecretBox(encoding.Encodable, StringFixer, object):
         :param ciphertext: [:class:`bytes`] The encrypted message to decrypt
         :param nonce: [:class:`bytes`] The nonce used when encrypting the
             ciphertext
-        :param encoder: The encoder used to decode the ciphertext.
+        :param encoder: DEPRECATED: The encoder to use to decode the ciphertext
+        :param ciphertext_encoder: The encoder to use to decode the ciphertext
+        :param nonce_encoder: The encoder to use to decode the nonce
         :rtype: [:class:`bytes`]
         """
+        if encoder is not None:
+            warnings.warn("Use of encoder is deprecated. Please update your "
+                          "code to use ciphertext_encoder and nonce_encoder "
+                          "instead.",
+                          DeprecationWarning)
+            ciphertext_encoder = encoder
+
         # Decode our ciphertext
-        ciphertext = encoder.decode(ciphertext)
+        ciphertext = ciphertext_encoder.decode(ciphertext)
+
+        # Decode our nonce
+        nonce = nonce_encoder.decode(nonce)
 
         if nonce is None:
             # If we were given the nonce and ciphertext combined, split them.


### PR DESCRIPTION
This is a follow up to #504, however, this PR is still relevant even if #505 is merged.

This PR adds separate encoders for `smessage` and `signature`, and for `ciphertext` and `nonce`.

Using the previous `encoder` parameter now works, but emits a warning with instructions to use `message_encoder` and `signature_encoder` or `ciphertext_encoder` and `nonce_encoder` instead, as appropriate.

Both the warning and messages are tested.

At-mentioning people here because I think they might be interested (apologies if this is annoying, but I think you will all have some valuable input): @lmctv, @reaperhulk, @alex.