### PR TITLE
RFC Deprecate encoding of detached parts

### DIFF
--- a/docs/signing.rst
+++ b/docs/signing.rst
@@ -17,16 +17,15 @@ use it to validate that your messages are actually authentic.
 Example
 -------
 
-Signing and verifying a message without encoding the key or message
-
 Signer's perspective (:class:`~nacl.signing.SigningKey`)
 
 .. testcode::
 
-    from nacl.signing import SigningKey
+    import nacl.encoding
+    import nacl.signing
 
     # Generate a new random signing key
-    signing_key = SigningKey.generate()
+    signing_key = nacl.signing.SigningKey.generate()
 
     # Sign a message with the signing key
     signed = signing_key.sign(b"Attack at Dawn")
@@ -35,138 +34,26 @@ Signer's perspective (:class:`~nacl.signing.SigningKey`)
     verify_key = signing_key.verify_key
 
     # Serialize the verify key to send it to a third party
-    verify_key_bytes = verify_key.encode()
+    verify_key_hex = verify_key.encode(encoder=nacl.encoding.HexEncoder)
 
 Verifier's perspective (:class:`~nacl.signing.VerifyKey`)
 
 .. testcode::
 
-    from nacl.signing import VerifyKey
+    import nacl.signing
 
     # Create a VerifyKey object from a hex serialized public key
-    verify_key = VerifyKey(verify_key_bytes)
+    verify_key = nacl.signing.VerifyKey(verify_key_hex,
+                                        encoder=nacl.encoding.HexEncoder)
 
     # Check the validity of a message's signature
-    # The message and the signature can either be passed together, or
-    # separately if the signature is decoded to raw bytes.
-    # These are equivalent:
+    # The message and the signature can either be passed separately or
+    # concatenated together.  These are equivalent:
     verify_key.verify(signed)
     verify_key.verify(signed.message, signed.signature)
 
     # Alter the signed message text
     forged = signed[:-1] + bytes([int(signed[-1]) ^ 1])
-    # Will raise nacl.exceptions.BadSignatureError, since the signature check
-    # is failing
-    verify_key.verify(forged)
-
-.. testoutput::
-
-    Traceback (most recent call last):
-     ...
-    nacl.exceptions.BadSignatureError: Signature was forged or corrupt
-
-
-Example
--------
-
-Signing and verifying a message encoded with HexEncoder
-
-Signer's perspective (:class:`~nacl.signing.SigningKey`)
-
-.. testcode::
-
-    from nacl.encoding import HexEncoder
-    from nacl.signing import SigningKey
-
-    # Generate a new random signing key
-    signing_key = SigningKey.generate()
-
-    # Sign a message with the signing key
-    signed_hex = signing_key.sign(b"Attack at Dawn", encoder=HexEncoder)
-
-    # Obtain the verify key for a given signing key
-    verify_key = signing_key.verify_key
-
-    # Serialize the verify key to send it to a third party
-    verify_key_hex = verify_key.encode(encoder=HexEncoder)
-
-Verifier's perspective (:class:`~nacl.signing.VerifyKey`)
-
-.. testcode::
-
-    from nacl.encoding import HexEncoder
-    from nacl.signing import VerifyKey
-
-    # Create a VerifyKey object from a hex serialized public key
-    verify_key = VerifyKey(verify_key_hex, encoder=HexEncoder)
-
-    # Check the validity of a message's signature
-    # The message and the signature can either be passed together, or
-    # separately if the signature is decoded to raw bytes.
-    # These are equivalent:
-    verify_key.verify(signed_hex, encoder=HexEncoder)
-    signature_bytes = HexEncoder.decode(signed_hex.signature)
-    verify_key.verify(signed_hex.message, signature_bytes,
-                      encoder=HexEncoder)
-
-    # Alter the signed message text
-    forged = signed_hex[:-1] + bytes([int(signed_hex[-1]) ^ 1])
-    # Will raise nacl.exceptions.BadSignatureError, since the signature check
-    # is failing
-    verify_key.verify(forged)
-
-.. testoutput::
-
-    Traceback (most recent call last):
-     ...
-    nacl.exceptions.BadSignatureError: Signature was forged or corrupt
-
-
-Example
--------
-
-Signing and verifying a message encoded with Base64Encoder
-
-Signer's perspective (:class:`~nacl.signing.SigningKey`)
-
-.. testcode::
-
-    from nacl.encoding import Base64Encoder
-    from nacl.signing import SigningKey
-
-    # Generate a new random signing key
-    signing_key = SigningKey.generate()
-
-    # Sign a message with the signing key
-    signed_b64 = signing_key.sign(b"Attack at Dawn", encoder=Base64Encoder)
-
-    # Obtain the verify key for a given signing key
-    verify_key = signing_key.verify_key
-
-    # Serialize the verify key to send it to a third party
-    verify_key_b64 = verify_key.encode(encoder=Base64Encoder)
-
-Verifier's perspective (:class:`~nacl.signing.VerifyKey`)
-
-.. testcode::
-
-    from nacl.encoding import Base64Encoder
-    from nacl.signing import VerifyKey
-
-    # Create a VerifyKey object from a base64 serialized public key
-    verify_key = VerifyKey(verify_key_b64, encoder=Base64Encoder)
-
-    # Check the validity of a message's signature
-    # The message and the signature can either be passed together, or
-    # separately if the signature is decoded to raw bytes.
-    # These are equivalent:
-    verify_key.verify(signed_b64, encoder=Base64Encoder)
-    signature_bytes = Base64Encoder.decode(signed_b64.signature)
-    verify_key.verify(signed_b64.message, signature_bytes,
-                      encoder=Base64Encoder)
-
-    # Alter the signed message text
-    forged = signed_b64[:-1] + bytes([int(signed_b64[-1]) ^ 1])
     # Will raise nacl.exceptions.BadSignatureError, since the signature check
     # is failing
     verify_key.verify(forged)

--- a/src/nacl/signing.py
+++ b/src/nacl/signing.py
@@ -104,10 +104,10 @@ class VerifyKey(encoding.Encodable, StringFixer, object):
         if signature is not None:
             # If we were given the message and signature separately, combine
             #   them.
-            smessage = signature + encoder.decode(smessage)
-        else:
-            # Decode the signed message
-            smessage = encoder.decode(smessage)
+            smessage = signature + smessage
+
+        # Decode the signed message
+        smessage = encoder.decode(smessage)
 
         return nacl.bindings.crypto_sign_open(smessage, self._key)
 

--- a/src/nacl/signing.py
+++ b/src/nacl/signing.py
@@ -21,7 +21,7 @@ from nacl import encoding
 from nacl import exceptions as exc
 from nacl.public import (PrivateKey as _Curve25519_PrivateKey,
                          PublicKey as _Curve25519_PublicKey)
-from nacl.utils import StringFixer, random
+from nacl.utils import PyNaclDeprecated, StringFixer, random
 
 
 class SignedMessage(bytes):
@@ -58,7 +58,9 @@ class SignedMessage(bytes):
         The signature contained within the :class:`SignedMessage`,
         encoded as requested on signature generation
         """
-        warn("Deprecated attribute")
+        warn("Access to the encoded attribute `.signature "
+             "is deprecated. Use `.raw_signature instead",
+             PyNaclDeprecated)
         return self._encoder.encode(self._signature)
 
     @property
@@ -67,7 +69,9 @@ class SignedMessage(bytes):
         The message contained within the :class:`SignedMessage`.
         encoded as requested on signature generation
         """
-        warn("Deprecated attribute")
+        warn("Access to the encoded attribute `.message "
+             "is deprecated. Use `.raw_message instead",
+             PyNaclDeprecated)
         return self._encoder.encode(self._message)
 
 
@@ -122,13 +126,18 @@ class VerifyKey(encoding.Encodable, StringFixer, object):
             signature.
         :rtype: :class:`bytes`
         """
-        if signature is not None:
-            # If we were given the message and signature separately, combine
-            #   them.
-            smessage = signature + smessage
 
         # Decode the signed message
         smessage = encoder.decode(smessage)
+
+        if signature is not None:
+            if len(signature) == nacl.bindings.crypto_sign_BYTES:
+                smessage = signature + smessage
+            else:
+                warn("Passing in encoded detached signatures is deprecated. "
+                     "Use raw bytes representation instead",
+                     PyNaclDeprecated)
+                smessage = encoder.decode(signature) + smessage
 
         return nacl.bindings.crypto_sign_open(smessage, self._key)
 

--- a/src/nacl/signing.py
+++ b/src/nacl/signing.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Donald Stufft and individual contributors
+# Copyright 2013-2019 Donald Stufft and individual contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/nacl/utils.py
+++ b/src/nacl/utils.py
@@ -19,11 +19,7 @@ import os
 import six
 
 
-class PyNaclWarning(UserWarning):
-    pass
-
-
-class PyNaclDeprecated(PyNaclWarning):
+class PyNaclDeprecated(UserWarning):
     pass
 
 

--- a/src/nacl/utils.py
+++ b/src/nacl/utils.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Donald Stufft and individual contributors
+# Copyright 2013-2019 Donald Stufft and individual contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/src/nacl/utils.py
+++ b/src/nacl/utils.py
@@ -19,6 +19,14 @@ import os
 import six
 
 
+class PyNaclWarning(UserWarning):
+    pass
+
+
+class PyNaclDeprecated(PyNaclWarning):
+    pass
+
+
 class EncryptedMessage(bytes):
     """
     A bytes subclass that holds a messaged that has been encrypted by a

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -24,6 +24,7 @@ from nacl.bindings import crypto_sign_PUBLICKEYBYTES, crypto_sign_SEEDBYTES
 from nacl.encoding import HexEncoder
 from nacl.exceptions import BadSignatureError
 from nacl.signing import SignedMessage, SigningKey, VerifyKey
+from nacl.utils import PyNaclDeprecated
 
 
 def tohex(b):
@@ -101,8 +102,9 @@ class TestSigningKey:
 
         assert message == binascii.hexlify(signed.raw_message)
         assert signed == expected
-        assert signed.message == message
-        assert signed.signature == signature
+        with pytest.warns(PyNaclDeprecated):
+            assert signed.message == message
+            assert signed.signature == signature
 
 
 class TestVerifyKey:
@@ -149,9 +151,10 @@ class TestVerifyKey:
         assert binascii.hexlify(
             key.verify(signed, encoder=HexEncoder),
         ) == message
-        assert binascii.hexlify(
-            key.verify(message, signature, encoder=HexEncoder),
-        ) == message
+        with pytest.warns(PyNaclDeprecated):
+            assert binascii.hexlify(
+                key.verify(message, signature, encoder=HexEncoder),
+            ) == message
 
     def test_invalid_signed_message(self):
         skey = SigningKey.generate()

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -99,6 +99,7 @@ class TestSigningKey:
             encoder=HexEncoder,
         )
 
+        assert message == binascii.hexlify(signed.raw_message)
         assert signed == expected
         assert signed.message == message
         assert signed.signature == signature
@@ -155,7 +156,7 @@ class TestVerifyKey:
     def test_invalid_signed_message(self):
         skey = SigningKey.generate()
         smessage = skey.sign(b"A Test Message!")
-        signature, message = smessage.signature, b"A Forged Test Message!"
+        signature, message = smessage.raw_signature, b"A Forged Test Message!"
 
         # Small sanity check
         assert skey.verify_key.verify(smessage)

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -21,7 +21,7 @@ import pytest
 from utils import assert_equal, assert_not_equal, read_crypto_test_vectors
 
 from nacl.bindings import crypto_sign_PUBLICKEYBYTES, crypto_sign_SEEDBYTES
-from nacl.encoding import Base64Encoder, HexEncoder
+from nacl.encoding import HexEncoder
 from nacl.exceptions import BadSignatureError
 from nacl.signing import SignedMessage, SigningKey, VerifyKey
 
@@ -149,8 +149,7 @@ class TestVerifyKey:
             key.verify(signed, encoder=HexEncoder),
         ) == message
         assert binascii.hexlify(
-            key.verify(message, HexEncoder.decode(signature),
-                       encoder=HexEncoder),
+            key.verify(message, signature, encoder=HexEncoder),
         ) == message
 
     def test_invalid_signed_message(self):
@@ -167,38 +166,6 @@ class TestVerifyKey:
         with pytest.raises(BadSignatureError):
             forged = SignedMessage(signature + message)
             skey.verify_key.verify(forged)
-
-    def test_base64_smessage_with_detached_sig_matches_with_attached_sig(self):
-        sk = SigningKey.generate()
-        vk = sk.verify_key
-
-        smsg = sk.sign(b"Hello World in base64", encoder=Base64Encoder)
-
-        msg = smsg.message
-        b64sig = smsg.signature
-
-        sig = Base64Encoder.decode(b64sig)
-
-        assert vk.verify(msg, sig, encoder=Base64Encoder) == \
-            vk.verify(smsg, encoder=Base64Encoder)
-
-        assert Base64Encoder.decode(msg) == b"Hello World in base64"
-
-    def test_hex_smessage_with_detached_sig_matches_with_attached_sig(self):
-        sk = SigningKey.generate()
-        vk = sk.verify_key
-
-        smsg = sk.sign(b"Hello World in hex", encoder=HexEncoder)
-
-        msg = smsg.message
-        hexsig = smsg.signature
-
-        sig = HexEncoder.decode(hexsig)
-
-        assert vk.verify(msg, sig, encoder=HexEncoder) == \
-            vk.verify(smsg, encoder=HexEncoder)
-
-        assert HexEncoder.decode(msg) == b"Hello World in hex"
 
     def test_key_conversion(self):
         keypair_seed = (b"421151a459faeade3d247115f94aedae"

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Donald Stufft and individual contributors
+# Copyright 2013-2019 Donald Stufft and individual contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.


### PR DESCRIPTION
@blag @pyca/pynacl-core This is a follow-up to the revert of #504, to show a real proposal instead of some hand-waving... I think this way we gain a clear path to deprecate the encoded parts, while keeping the capability to encode the full signed message, which someone seems to find useful in simple cases.