### PR TITLE
Wrap raw blake2 state in a python class.

### DIFF
--- a/src/nacl/bindings/__init__.py
+++ b/src/nacl/bindings/__init__.py
@@ -1,4 +1,4 @@
-# Copyright 2013 Donald Stufft and individual contributors
+# Copyright 2013-2019 Donald Stufft and individual contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -59,7 +59,6 @@ from nacl.bindings.crypto_generichash import (
     generichash_blake2b_init as crypto_generichash_blake2b_init,
     generichash_blake2b_salt_personal as
     crypto_generichash_blake2b_salt_personal,
-    generichash_blake2b_state_copy as crypto_generichash_blake2b_state_copy,
     generichash_blake2b_update as crypto_generichash_blake2b_update
 )
 from nacl.bindings.crypto_hash import (
@@ -253,7 +252,6 @@ __all__ = [
     "crypto_generichash_blake2b_init",
     "crypto_generichash_blake2b_update",
     "crypto_generichash_blake2b_final",
-    "crypto_generichash_blake2b_state_copy",
 
     "crypto_kx_keypair",
     "crypto_kx_seed_keypair",

--- a/src/nacl/bindings/crypto_generichash.py
+++ b/src/nacl/bindings/crypto_generichash.py
@@ -14,8 +14,6 @@
 
 from __future__ import absolute_import, division, print_function
 
-import copy
-
 from six import integer_types
 
 from nacl import exceptions as exc

--- a/src/nacl/bindings/crypto_generichash.py
+++ b/src/nacl/bindings/crypto_generichash.py
@@ -14,6 +14,8 @@
 
 from __future__ import absolute_import, division, print_function
 
+import copy
+
 from six import integer_types
 
 from nacl import exceptions as exc
@@ -138,8 +140,6 @@ class Blake2State(object):
         ffi.memmove(_st._statebuf,
                     self._statebuf, crypto_generichash_STATEBYTES)
         return _st
-
-    copy = __copy__
 
 
 def generichash_blake2b_init(key=b'', salt=b'',

--- a/src/nacl/bindings/crypto_generichash.py
+++ b/src/nacl/bindings/crypto_generichash.py
@@ -126,17 +126,17 @@ class Blake2State(object):
     """
     Python-level wrapper for the crypto_generichash_blake2b state buffer
     """
-    __slots__ = ['statebuf', 'digest_size']
+    __slots__ = ['_statebuf', 'digest_size']
 
     def __init__(self, digest_size):
-        self.statebuf = ffi.new("unsigned char[]",
-                                crypto_generichash_STATEBYTES)
+        self._statebuf = ffi.new("unsigned char[]",
+                                 crypto_generichash_STATEBYTES)
         self.digest_size = digest_size
 
     def __copy__(self):
         _st = self.__class__(self.digest_size)
-        ffi.memmove(_st.statebuf,
-                    self.statebuf, crypto_generichash_STATEBYTES)
+        ffi.memmove(_st._statebuf,
+                    self._statebuf, crypto_generichash_STATEBYTES)
         return _st
 
     copy = __copy__
@@ -164,7 +164,7 @@ def generichash_blake2b_init(key=b'', salt=b'',
                         the default digest size is
                         :py:data:`.crypto_generichash_BYTES`
     :type digest_size: int
-    :return: a initizialized :py:class:`.Blake2State`
+    :return: a initialized :py:class:`.Blake2State`
     :rtype: object
     """
 
@@ -179,7 +179,7 @@ def generichash_blake2b_init(key=b'', salt=b'',
     ffi.memmove(_salt, salt, len(salt))
     ffi.memmove(_person, person, len(person))
 
-    rc = lib.crypto_generichash_blake2b_init_salt_personal(state.statebuf,
+    rc = lib.crypto_generichash_blake2b_init_salt_personal(state._statebuf,
                                                            key, len(key),
                                                            digest_size,
                                                            _salt, _person)
@@ -207,7 +207,8 @@ def generichash_blake2b_update(state, data):
            'Input data must be a bytes sequence',
            raising=exc.TypeError)
 
-    rc = lib.crypto_generichash_blake2b_update(state.statebuf, data, len(data))
+    rc = lib.crypto_generichash_blake2b_update(state._statebuf,
+                                               data, len(data))
     ensure(rc == 0, 'Unexpected failure',
            raising=exc.RuntimeError)
 
@@ -227,7 +228,7 @@ def generichash_blake2b_final(state):
            raising=exc.TypeError)
 
     _digest = ffi.new("unsigned char[]", crypto_generichash_BYTES_MAX)
-    rc = lib.crypto_generichash_blake2b_final(state.statebuf,
+    rc = lib.crypto_generichash_blake2b_final(state._statebuf,
                                               _digest, state.digest_size)
 
     ensure(rc == 0, 'Unexpected failure',

--- a/src/nacl/bindings/crypto_generichash.py
+++ b/src/nacl/bindings/crypto_generichash.py
@@ -133,7 +133,7 @@ class Blake2State(object):
                                  crypto_generichash_STATEBYTES)
         self.digest_size = digest_size
 
-    def __copy__(self):
+    def copy(self):
         _st = self.__class__(self.digest_size)
         ffi.memmove(_st._statebuf,
                     self._statebuf, crypto_generichash_STATEBYTES)

--- a/src/nacl/bindings/crypto_generichash.py
+++ b/src/nacl/bindings/crypto_generichash.py
@@ -133,6 +133,14 @@ class Blake2State(object):
                                  crypto_generichash_STATEBYTES)
         self.digest_size = digest_size
 
+    def __reduce__(self):
+        """
+        Raise the same exception as hashlib's blake implementation
+        on copy.copy()
+        """
+        raise TypeError("can't pickle {} objects".format(
+            self.__class__.__name__))
+
     def copy(self):
         _st = self.__class__(self.digest_size)
         ffi.memmove(_st._statebuf,

--- a/src/nacl/bindings/crypto_generichash.py
+++ b/src/nacl/bindings/crypto_generichash.py
@@ -13,7 +13,6 @@
 # limitations under the License.
 
 from __future__ import absolute_import, division, print_function
-import copy
 
 from six import integer_types
 
@@ -130,13 +129,17 @@ class Blake2State(object):
     __slots__ = ['_statebuf', 'digest_size']
 
     def __init__(self, digest_size):
-        self._statebuf = bytearray(crypto_generichash_STATEBYTES)
+        self._statebuf = ffi.new("unsigned char[]",
+                                 crypto_generichash_STATEBYTES)
         self.digest_size = digest_size
 
     def __copy__(self):
         _st = self.__class__(self.digest_size)
-        _st._statebuf = copy.copy(self._statebuf)
+        ffi.memmove(_st._statebuf,
+                    self._statebuf, crypto_generichash_STATEBYTES)
         return _st
+
+    copy = __copy__
 
 
 def generichash_blake2b_init(key=b'', salt=b'',
@@ -176,13 +179,10 @@ def generichash_blake2b_init(key=b'', salt=b'',
     ffi.memmove(_salt, salt, len(salt))
     ffi.memmove(_person, person, len(person))
 
-    rc = lib.crypto_generichash_blake2b_init_salt_personal(
-        ffi.from_buffer(state._statebuf),
-        key, len(key),
-        digest_size,
-        _salt,
-        _person
-    )
+    rc = lib.crypto_generichash_blake2b_init_salt_personal(state._statebuf,
+                                                           key, len(key),
+                                                           digest_size,
+                                                           _salt, _person)
     ensure(rc == 0, 'Unexpected failure',
            raising=exc.RuntimeError)
 
@@ -207,11 +207,8 @@ def generichash_blake2b_update(state, data):
            'Input data must be a bytes sequence',
            raising=exc.TypeError)
 
-    rc = lib.crypto_generichash_blake2b_update(
-        ffi.from_buffer(state._statebuf),
-        data,
-        len(data)
-    )
+    rc = lib.crypto_generichash_blake2b_update(state._statebuf,
+                                               data, len(data))
     ensure(rc == 0, 'Unexpected failure',
            raising=exc.RuntimeError)
 
@@ -231,11 +228,8 @@ def generichash_blake2b_final(state):
            raising=exc.TypeError)
 
     _digest = ffi.new("unsigned char[]", crypto_generichash_BYTES_MAX)
-    rc = lib.crypto_generichash_blake2b_final(
-        ffi.from_buffer(state._statebuf),
-        _digest,
-        state.digest_size
-    )
+    rc = lib.crypto_generichash_blake2b_final(state._statebuf,
+                                              _digest, state.digest_size)
 
     ensure(rc == 0, 'Unexpected failure',
            raising=exc.RuntimeError)

--- a/src/nacl/hashlib.py
+++ b/src/nacl/hashlib.py
@@ -1,4 +1,4 @@
-# Copyright 2016 Donald Stufft and individual contributors
+# Copyright 2016-2019 Donald Stufft and individual contributors
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -30,7 +30,6 @@ PERSONALBYTES = nacl.bindings.crypto_generichash_PERSONALBYTES
 
 _b2b_init = nacl.bindings.crypto_generichash_blake2b_init
 _b2b_final = nacl.bindings.crypto_generichash_blake2b_final
-_b2b_copy = nacl.bindings.crypto_generichash_blake2b_state_copy
 _b2b_update = nacl.bindings.crypto_generichash_blake2b_update
 
 
@@ -56,7 +55,7 @@ class blake2b(object):
         :param key: the key to be set for keyed MAC/PRF usage; if set,
                     the key must be at most :py:data:`.KEYBYTES_MAX` long
         :type key: bytes
-        :param salt: an initialization salt at most
+        :param salt: a initialization salt at most
                      :py:attr:`.SALT_SIZE` long; it will be zero-padded
                      if needed
         :type salt: bytes
@@ -89,17 +88,19 @@ class blake2b(object):
         _b2b_update(self._state, data)
 
     def digest(self):
-        _st = nacl.bindings.crypto_generichash_blake2b_state_copy(self._state)
-        return _b2b_final(_st, self.digest_size)
+        _st = self._state.copy()
+        return _b2b_final(_st)
 
     def hexdigest(self):
         return bytes_as_string(binascii.hexlify(self.digest()))
 
-    def copy(self):
+    def __copy__(self):
         _cp = type(self)(digest_size=self.digest_size)
-        _st = _b2b_copy(self._state)
+        _st = self._state.copy()
         _cp._state = _st
         return _cp
+
+    copy = __copy__
 
 
 def scrypt(password, salt='', n=2**20, r=8, p=1,

--- a/src/nacl/hashlib.py
+++ b/src/nacl/hashlib.py
@@ -100,6 +100,14 @@ class blake2b(object):
         _cp._state = _st
         return _cp
 
+    def __reduce__(self):
+        """
+        Raise the same exception as hashlib's blake implementation
+        on copy.copy()
+        """
+        raise TypeError("can't pickle {} objects".format(
+            self.__class__.__name__))
+
 
 def scrypt(password, salt='', n=2**20, r=8, p=1,
            maxmem=2**25, dklen=64):

--- a/src/nacl/hashlib.py
+++ b/src/nacl/hashlib.py
@@ -15,7 +15,6 @@
 from __future__ import absolute_import, division, print_function
 
 import binascii
-import copy
 
 import nacl.bindings
 from nacl.utils import bytes_as_string
@@ -89,7 +88,7 @@ class blake2b(object):
         _b2b_update(self._state, data)
 
     def digest(self):
-        _st = copy.copy(self._state)
+        _st = self._state.copy()
         return _b2b_final(_st)
 
     def hexdigest(self):
@@ -97,7 +96,7 @@ class blake2b(object):
 
     def __copy__(self):
         _cp = type(self)(digest_size=self.digest_size)
-        _st = copy.copy(self._state)
+        _st = self._state.copy()
         _cp._state = _st
         return _cp
 

--- a/src/nacl/hashlib.py
+++ b/src/nacl/hashlib.py
@@ -15,6 +15,7 @@
 from __future__ import absolute_import, division, print_function
 
 import binascii
+import copy
 
 import nacl.bindings
 from nacl.utils import bytes_as_string
@@ -88,7 +89,7 @@ class blake2b(object):
         _b2b_update(self._state, data)
 
     def digest(self):
-        _st = self._state.copy()
+        _st = copy.copy(self._state)
         return _b2b_final(_st)
 
     def hexdigest(self):
@@ -96,7 +97,7 @@ class blake2b(object):
 
     def __copy__(self):
         _cp = type(self)(digest_size=self.digest_size)
-        _st = self._state.copy()
+        _st = copy.copy(self._state)
         _cp._state = _st
         return _cp
 

--- a/src/nacl/hashlib.py
+++ b/src/nacl/hashlib.py
@@ -15,7 +15,6 @@
 from __future__ import absolute_import, division, print_function
 
 import binascii
-import copy
 
 import nacl.bindings
 from nacl.utils import bytes_as_string
@@ -89,19 +88,17 @@ class blake2b(object):
         _b2b_update(self._state, data)
 
     def digest(self):
-        _st = copy.copy(self._state)
+        _st = self._state.copy()
         return _b2b_final(_st)
 
     def hexdigest(self):
         return bytes_as_string(binascii.hexlify(self.digest()))
 
-    def __copy__(self):
+    def copy(self):
         _cp = type(self)(digest_size=self.digest_size)
-        _st = copy.copy(self._state)
+        _st = self._state.copy()
         _cp._state = _st
         return _cp
-
-    copy = __copy__
 
 
 def scrypt(password, salt='', n=2**20, r=8, p=1,

--- a/tests/test_generichash.py
+++ b/tests/test_generichash.py
@@ -15,6 +15,7 @@
 from __future__ import absolute_import, division, print_function
 
 import binascii
+import copy
 import json
 import os
 
@@ -98,6 +99,24 @@ def test_hash_blake2b(message, key, salt, person, outlen, output):
     out = nacl.hash.blake2b(msg, digest_size=outlen, key=k,
                             salt=slt, person=pers)
     assert (out == output)
+
+
+def test_expected_hashlib_level_pickle_and_copy_failures():
+    h = nacl.hashlib.blake2b()
+    with pytest.raises(TypeError):
+        copy.deepcopy(h)
+    with pytest.raises(TypeError):
+        copy.copy(h)
+
+
+def test_expected_bindings_level_pickle_and_copy_failures():
+    from nacl.bindings.crypto_generichash import (Blake2State,
+                                                  crypto_generichash_BYTES)
+    st = Blake2State(crypto_generichash_BYTES)
+    with pytest.raises(TypeError):
+        copy.deepcopy(st)
+    with pytest.raises(TypeError):
+        copy.copy(st)
 
 
 @pytest.mark.parametrize(["message", "key", "outlen", "output"],


### PR DESCRIPTION
This way we avoid leaking raw buffers, and can type check all blake2 state usages.