### PR TITLE
Update secret.rst

### DIFF
--- a/docs/secret.rst
+++ b/docs/secret.rst
@@ -181,5 +181,5 @@ Reference
 Algorithm details
 -----------------
 
-:Encryption: `Salsa20 stream cipher <https://en.wikipedia.org/wiki/Salsa20>`_
+:Encryption: `XSalsa20 stream cipher <https://libsodium.gitbook.io/doc/advanced/stream_ciphers/xsalsa20>`_
 :Authentication: `Poly1305 MAC <https://en.wikipedia.org/wiki/Poly1305-AES>`_


### PR DESCRIPTION
As described in https://libsodium.gitbook.io/doc/secret-key_cryptography/authenticated_encryption#algorithm-details, libsodium uses XSalsa20 instead of Salsa20 for its underlying encryption, also update the link to point to the libsodium docs about XSalsa20 for reference