### PR TITLE
Force positive size for plaintext output array 

### DIFF
--- a/src/nacl/bindings/crypto_box.py
+++ b/src/nacl/bindings/crypto_box.py
@@ -304,10 +304,11 @@ def crypto_box_seal_open(ciphertext, pk, sk):
     _clen = len(ciphertext)
     _mlen = _clen - crypto_box_SEALBYTES
 
-    plaintext = ffi.new("unsigned char[]", _mlen)
+    # zero-length malloc results are implementation.dependent
+    plaintext = ffi.new("unsigned char[]", max(1, _mlen))
 
     res = lib.crypto_box_seal_open(plaintext, ciphertext, _clen, pk, sk)
     ensure(res == 0, "An error occurred trying to decrypt the message",
            raising=exc.CryptoError)
 
-    return ffi.buffer(plaintext, _mlen)[:]
+    return ffi.buffer(plaintext, max(0, _mlen))[:]

--- a/src/nacl/bindings/crypto_box.py
+++ b/src/nacl/bindings/crypto_box.py
@@ -302,6 +302,12 @@ def crypto_box_seal_open(ciphertext, pk, sk):
         raise exc.ValueError("Invalid secret key")
 
     _clen = len(ciphertext)
+
+    ensure(_clen >= crypto_box_SEALBYTES,
+           ("Input cyphertext must be "
+            "at least {} long").format(crypto_box_SEALBYTES),
+           raising=exc.TypeError)
+
     _mlen = _clen - crypto_box_SEALBYTES
 
     # zero-length malloc results are implementation.dependent
@@ -311,4 +317,4 @@ def crypto_box_seal_open(ciphertext, pk, sk):
     ensure(res == 0, "An error occurred trying to decrypt the message",
            raising=exc.CryptoError)
 
-    return ffi.buffer(plaintext, max(0, _mlen))[:]
+    return ffi.buffer(plaintext, _mlen)[:]

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -234,16 +234,36 @@ def test_sign_test_key_conversion():
                                     "dd12ad910b654455798b4667d73de166")
 
 
+def test_box_seal_empty():
+    A_pubkey, A_secretkey = c.crypto_box_keypair()
+    empty = b""
+    msg = c.crypto_box_seal(empty, A_pubkey)
+    decoded = c.crypto_box_seal_open(msg,
+                                     A_pubkey,
+                                     A_secretkey)
+    assert decoded == empty
+
+
 def test_box_seal_wrong_lengths():
     A_pubkey, A_secretkey = c.crypto_box_keypair()
     with pytest.raises(ValueError):
         c.crypto_box_seal(b"abc", A_pubkey[:-1])
     with pytest.raises(ValueError):
-        c.crypto_box_seal_open(
-            b"abc", b"", A_secretkey)
+        c.crypto_box_seal_open(b"abc",
+                               b"",
+                               A_secretkey
+                               )
     with pytest.raises(ValueError):
-        c.crypto_box_seal_open(
-            b"abc", A_pubkey, A_secretkey[:-1])
+        c.crypto_box_seal_open(b"abc",
+                               A_pubkey,
+                               A_secretkey[:-1]
+                               )
+    msg = c.crypto_box_seal(b"", A_pubkey)
+    with pytest.raises(CryptoError):
+        c.crypto_box_seal_open(msg[:-1],
+                               A_pubkey,
+                               A_secretkey
+                               )
 
 
 def test_box_seal_wrong_types():

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -244,6 +244,18 @@ def test_box_seal_empty():
     assert decoded == empty
 
 
+def test_box_seal_empty_is_verified():
+    A_pubkey, A_secretkey = c.crypto_box_keypair()
+    empty = b""
+    amsg = bytearray(c.crypto_box_seal(empty, A_pubkey))
+    amsg[-1] ^= 1
+    msg = bytes(amsg)
+    with pytest.raises(CryptoError):
+        c.crypto_box_seal_open(msg,
+                               A_pubkey,
+                               A_secretkey)
+
+
 def test_box_seal_wrong_lengths():
     A_pubkey, A_secretkey = c.crypto_box_keypair()
     with pytest.raises(ValueError):

--- a/tests/test_sealed_box.py
+++ b/tests/test_sealed_box.py
@@ -21,6 +21,7 @@ import pytest
 from utils import read_crypto_test_vectors
 
 from nacl.encoding import HexEncoder
+from nacl.exceptions import CryptoError
 from nacl.public import PrivateKey, PublicKey, SealedBox
 
 
@@ -141,3 +142,26 @@ def test_sealed_box_public_key_cannot_decrypt(_privalice, pubalice,
             encrypted,
             encoder=HexEncoder,
         )
+
+
+def test_sealed_box_zero_length_plaintext():
+    empty_plaintext = b''
+    k = PrivateKey.generate()
+    enc_box = SealedBox(k.public_key)
+    dec_box = SealedBox(k)
+
+    msg = enc_box.encrypt(empty_plaintext)
+    decoded = dec_box.decrypt(msg)
+
+    assert decoded == empty_plaintext
+
+
+def test_sealed_box_too_short_msg():
+    empty_plaintext = b''
+    k = PrivateKey.generate()
+    enc_box = SealedBox(k.public_key)
+    dec_box = SealedBox(k)
+
+    msg = enc_box.encrypt(empty_plaintext)
+    with pytest.raises(CryptoError):
+        dec_box.decrypt(msg[:-1])


### PR DESCRIPTION
Solves #517. The tests have been verified as failing before applying the enclosed changes to `src/nacl/bindings/crypto_box.py`