### PR TITLE
Raise specific exception for unknown modular crypt identifier prefix

### DIFF
--- a/docs/password_hashing.rst
+++ b/docs/password_hashing.rst
@@ -129,7 +129,7 @@ and checks the compliance of the proposed password with the stored hash
     >>> res = nacl.pwhash.verify(wrong_hash, correct)
     Traceback (most recent call last):
         ...
-    nacl.exceptions.InvalidkeyError: given password_hash is not in a supported format
+    nacl.exceptions.CryptPrefixError: given password_hash is not in a supported format
 
 
 Key derivation

--- a/src/nacl/exceptions.py
+++ b/src/nacl/exceptions.py
@@ -47,6 +47,10 @@ class InvalidkeyError(CryptoError):
     pass
 
 
+class CryptPrefixError(InvalidkeyError):
+    pass
+
+
 def ensure(cond, *args, **kwds):
     """
     Return if a condition is true, otherwise raise a caller-configurable

--- a/src/nacl/pwhash/__init__.py
+++ b/src/nacl/pwhash/__init__.py
@@ -14,7 +14,7 @@
 
 from __future__ import absolute_import
 
-from nacl.exceptions import InvalidkeyError
+from nacl.exceptions import CryptPrefixError
 
 from . import _argon2, argon2i, argon2id, scrypt
 
@@ -69,7 +69,7 @@ def verify(password_hash, password):
     elif password_hash.startswith(scrypt.STRPREFIX):
         return scrypt.verify(password_hash, password)
     else:
-        raise(InvalidkeyError("given password_hash is not "
-                              "in a supported format"
-                              )
+        raise(CryptPrefixError("given password_hash is not "
+                               "in a supported format"
+                               )
               )

--- a/tests/test_pwhash.py
+++ b/tests/test_pwhash.py
@@ -483,6 +483,13 @@ def test_invalid_modular_scrypt_prefix():
         nacl.pwhash.verify(invalid_modular_hash, psw)
 
 
+def test_crypt_prefix_error():
+    psw = b'always invalid password'
+    invalid_modular_hash = b'$invalid_prefix$'
+    with pytest.raises(exc.CryptPrefixError):
+        nacl.pwhash.verify(invalid_modular_hash, psw)
+
+
 @pytest.mark.parametrize(("dk_size", "password", "salt",
                           "iters", "mem_kb", "pwhash"),
                          argon2i_raw_ref())


### PR DESCRIPTION
As requested in #519. I think this is ready for review.