### PR TITLE
 Expose new low-level ed25519 arithmetic and point multiplication

### DIFF
--- a/src/bindings/crypto_core.h
+++ b/src/bindings/crypto_core.h
@@ -15,7 +15,20 @@
 
 size_t crypto_scalarmult_ed25519_scalarbytes();
 size_t crypto_core_ed25519_bytes();
+size_t crypto_core_ed25519_scalarbytes(void);
+size_t crypto_core_ed25519_nonreducedscalarbytes(void);
 
 int crypto_core_ed25519_is_valid_point(const unsigned char *p);
 int crypto_core_ed25519_add(unsigned char *r, const unsigned char *p, const unsigned char *q);
 int crypto_core_ed25519_sub(unsigned char *r, const unsigned char *p, const unsigned char *q);
+
+int crypto_core_ed25519_scalar_invert(unsigned char *recip, const unsigned char *s);
+void crypto_core_ed25519_scalar_negate(unsigned char *neg, const unsigned char *s);
+void crypto_core_ed25519_scalar_complement(unsigned char *comp, const unsigned char *s);
+void crypto_core_ed25519_scalar_add(unsigned char *z, const unsigned char *x,
+                                    const unsigned char *y);
+void crypto_core_ed25519_scalar_sub(unsigned char *z, const unsigned char *x,
+                                    const unsigned char *y);
+void crypto_core_ed25519_scalar_mul(unsigned char *z, const unsigned char *x,
+                                    const unsigned char *y);
+void crypto_core_ed25519_scalar_reduce(unsigned char *r, const unsigned char *s);

--- a/src/bindings/crypto_scalarmult.h
+++ b/src/bindings/crypto_scalarmult.h
@@ -21,3 +21,6 @@ int crypto_scalarmult_base(unsigned char *q, const unsigned char *n);
 int crypto_scalarmult(unsigned char *q, const unsigned char *n, const unsigned char *p);
 int crypto_scalarmult_ed25519(unsigned char *q, const unsigned char *n, const unsigned char *p);
 int crypto_scalarmult_ed25519_base(unsigned char *q, const unsigned char *n);
+int crypto_scalarmult_ed25519_noclamp(unsigned char *q, const unsigned char *n,
+                                      const unsigned char *p);
+int crypto_scalarmult_ed25519_base_noclamp(unsigned char *q, const unsigned char *n);

--- a/src/nacl/bindings/__init__.py
+++ b/src/nacl/bindings/__init__.py
@@ -46,8 +46,13 @@ from nacl.bindings.crypto_box import (
     crypto_box_seal_open, crypto_box_seed_keypair,
 )
 from nacl.bindings.crypto_core import (
-    crypto_core_ed25519_BYTES, crypto_core_ed25519_add,
-    crypto_core_ed25519_is_valid_point, crypto_core_ed25519_sub
+    crypto_core_ed25519_BYTES, crypto_core_ed25519_NONREDUCEDSCALARBYTES,
+    crypto_core_ed25519_SCALARBYTES, crypto_core_ed25519_add,
+    crypto_core_ed25519_is_valid_point, crypto_core_ed25519_scalar_add,
+    crypto_core_ed25519_scalar_complement, crypto_core_ed25519_scalar_invert,
+    crypto_core_ed25519_scalar_mul, crypto_core_ed25519_scalar_negate,
+    crypto_core_ed25519_scalar_reduce, crypto_core_ed25519_scalar_sub,
+    crypto_core_ed25519_sub
 )
 from nacl.bindings.crypto_generichash import (
     crypto_generichash_BYTES, crypto_generichash_BYTES_MAX,
@@ -134,7 +139,8 @@ from nacl.bindings.crypto_scalarmult import (
     crypto_scalarmult, crypto_scalarmult_BYTES, crypto_scalarmult_SCALARBYTES,
     crypto_scalarmult_base, crypto_scalarmult_ed25519,
     crypto_scalarmult_ed25519_BYTES, crypto_scalarmult_ed25519_SCALARBYTES,
-    crypto_scalarmult_ed25519_base
+    crypto_scalarmult_ed25519_base, crypto_scalarmult_ed25519_base_noclamp,
+    crypto_scalarmult_ed25519_noclamp
 )
 from nacl.bindings.crypto_secretbox import (
     crypto_secretbox, crypto_secretbox_BOXZEROBYTES, crypto_secretbox_KEYBYTES,
@@ -227,10 +233,19 @@ __all__ = [
 
     "crypto_core_ed25519_BYTES",
     "crypto_core_ed25519_UNIFORMBYTES",
+    "crypto_core_ed25519_SCALARBYTES",
+    "crypto_core_ed25519_NONREDUCEDSCALARBYTES",
     "crypto_core_ed25519_add",
     "crypto_core_ed25519_from_uniform",
     "crypto_core_ed25519_is_valid_point",
     "crypto_core_ed25519_sub",
+    "crypto_core_ed25519_scalar_invert",
+    "crypto_core_ed25519_scalar_negate",
+    "crypto_core_ed25519_scalar_complement",
+    "crypto_core_ed25519_scalar_add",
+    "crypto_core_ed25519_scalar_sub",
+    "crypto_core_ed25519_scalar_mul",
+    "crypto_core_ed25519_scalar_reduce",
 
     "crypto_hash_BYTES",
     "crypto_hash_sha256_BYTES",
@@ -270,6 +285,8 @@ __all__ = [
     "crypto_scalarmult_ed25519_SCALARBYTES",
     "crypto_scalarmult_ed25519",
     "crypto_scalarmult_ed25519_base",
+    "crypto_scalarmult_ed25519_noclamp",
+    "crypto_scalarmult_ed25519_base_noclamp",
 
     "crypto_secretbox_KEYBYTES",
     "crypto_secretbox_NONCEBYTES",
@@ -390,6 +407,7 @@ __all__ = [
     "sodium_pad",
     "sodium_unpad",
 ]
+
 
 # Initialize Sodium
 sodium_init()

--- a/src/nacl/bindings/crypto_core.py
+++ b/src/nacl/bindings/crypto_core.py
@@ -20,6 +20,9 @@ from nacl.exceptions import ensure
 
 
 crypto_core_ed25519_BYTES = lib.crypto_core_ed25519_bytes()
+crypto_core_ed25519_SCALARBYTES = lib.crypto_core_ed25519_scalarbytes()
+crypto_core_ed25519_NONREDUCEDSCALARBYTES = \
+    lib.crypto_core_ed25519_nonreducedscalarbytes()
 
 
 def crypto_core_ed25519_is_valid_point(p):
@@ -102,3 +105,197 @@ def crypto_core_ed25519_sub(p, q):
            raising=exc.RuntimeError)
 
     return ffi.buffer(r, crypto_core_ed25519_BYTES)[:]
+
+
+def crypto_core_ed25519_scalar_invert(s):
+    """
+    Return the multiplicative inverse of integer ``s`` modulo ``L``,
+    i.e an integer ``i`` such that ``s * i = 1 (mod L)``, where ``L``
+    is the order of the main subgroup.
+
+    Raises a ``exc.RuntimeError`` if ``s`` is the integer zero.
+
+    :param s: a :py:data:`.crypto_core_ed25519_SCALARBYTES`
+              long bytes sequence representing an integer
+    :type s: bytes
+    :return: an integer represented as a
+              :py:data:`.crypto_core_ed25519_SCALARBYTES` long bytes sequence
+    :rtype: bytes
+    """
+    ensure(isinstance(s, bytes) and
+           len(s) == crypto_core_ed25519_SCALARBYTES,
+           'Integer s must be a {} long bytes sequence'.format(
+           'crypto_core_ed25519_SCALARBYTES'),
+           raising=exc.TypeError)
+
+    r = ffi.new("unsigned char[]", crypto_core_ed25519_SCALARBYTES)
+
+    rc = lib.crypto_core_ed25519_scalar_invert(r, s)
+    ensure(rc == 0,
+           'Unexpected library error',
+           raising=exc.RuntimeError)
+
+    return ffi.buffer(r, crypto_core_ed25519_SCALARBYTES)[:]
+
+
+def crypto_core_ed25519_scalar_negate(s):
+    """
+    Return the integer ``n`` such that ``s + n = 0 (mod L)``, where ``L``
+    is the order of the main subgroup.
+
+    :param s: a :py:data:`.crypto_core_ed25519_SCALARBYTES`
+              long bytes sequence representing an integer
+    :type s: bytes
+    :return: an integer represented as a
+              :py:data:`.crypto_core_ed25519_SCALARBYTES` long bytes sequence
+    :rtype: bytes
+    """
+    ensure(isinstance(s, bytes) and
+           len(s) == crypto_core_ed25519_SCALARBYTES,
+           'Integer s must be a {} long bytes sequence'.format(
+           'crypto_core_ed25519_SCALARBYTES'),
+           raising=exc.TypeError)
+
+    r = ffi.new("unsigned char[]", crypto_core_ed25519_SCALARBYTES)
+
+    lib.crypto_core_ed25519_scalar_negate(r, s)
+
+    return ffi.buffer(r, crypto_core_ed25519_SCALARBYTES)[:]
+
+
+def crypto_core_ed25519_scalar_complement(s):
+    """
+    Return the complement of integer ``s`` modulo ``L``, i.e. an integer
+    ``c`` such that ``s + c = 1 (mod L)``, where ``L`` is the order of
+    the main subgroup.
+
+    :param s: a :py:data:`.crypto_core_ed25519_SCALARBYTES`
+              long bytes sequence representing an integer
+    :type s: bytes
+    :return: an integer represented as a
+              :py:data:`.crypto_core_ed25519_SCALARBYTES` long bytes sequence
+    :rtype: bytes
+    """
+    ensure(isinstance(s, bytes) and
+           len(s) == crypto_core_ed25519_SCALARBYTES,
+           'Integer s must be a {} long bytes sequence'.format(
+           'crypto_core_ed25519_SCALARBYTES'),
+           raising=exc.TypeError)
+
+    r = ffi.new("unsigned char[]", crypto_core_ed25519_SCALARBYTES)
+
+    lib.crypto_core_ed25519_scalar_complement(r, s)
+
+    return ffi.buffer(r, crypto_core_ed25519_SCALARBYTES)[:]
+
+
+def crypto_core_ed25519_scalar_add(p, q):
+    """
+    Add integers ``p`` and ``p`` modulo ``L``, where ``L`` is the order of
+    the main subgroup.
+
+    :param p: a :py:data:`.crypto_core_ed25519_SCALARBYTES`
+              long bytes sequence representing an integer
+    :type p: bytes
+    :param q: a :py:data:`.crypto_core_ed25519_SCALARBYTES`
+              long bytes sequence representing an integer
+    :type q: bytes
+    :return: an integer represented as a
+              :py:data:`.crypto_core_ed25519_SCALARBYTES` long bytes sequence
+    :rtype: bytes
+    """
+    ensure(isinstance(p, bytes) and isinstance(q, bytes) and
+           len(p) == crypto_core_ed25519_SCALARBYTES and
+           len(q) == crypto_core_ed25519_SCALARBYTES,
+           'Each integer must be a {} long bytes sequence'.format(
+           'crypto_core_ed25519_SCALARBYTES'),
+           raising=exc.TypeError)
+
+    r = ffi.new("unsigned char[]", crypto_core_ed25519_SCALARBYTES)
+
+    lib.crypto_core_ed25519_scalar_add(r, p, q)
+
+    return ffi.buffer(r, crypto_core_ed25519_SCALARBYTES)[:]
+
+
+def crypto_core_ed25519_scalar_sub(p, q):
+    """
+    Subtract integers ``p`` and ``p`` modulo ``L``, where ``L`` is the
+    order of the main subgroup.
+
+    :param p: a :py:data:`.crypto_core_ed25519_SCALARBYTES`
+              long bytes sequence representing an integer
+    :type p: bytes
+    :param q: a :py:data:`.crypto_core_ed25519_SCALARBYTES`
+              long bytes sequence representing an integer
+    :type q: bytes
+    :return: an integer represented as a
+              :py:data:`.crypto_core_ed25519_SCALARBYTES` long bytes sequence
+    :rtype: bytes
+    """
+    ensure(isinstance(p, bytes) and isinstance(q, bytes) and
+           len(p) == crypto_core_ed25519_SCALARBYTES and
+           len(q) == crypto_core_ed25519_SCALARBYTES,
+           'Each integer must be a {} long bytes sequence'.format(
+           'crypto_core_ed25519_SCALARBYTES'),
+           raising=exc.TypeError)
+
+    r = ffi.new("unsigned char[]", crypto_core_ed25519_SCALARBYTES)
+
+    lib.crypto_core_ed25519_scalar_sub(r, p, q)
+
+    return ffi.buffer(r, crypto_core_ed25519_SCALARBYTES)[:]
+
+
+def crypto_core_ed25519_scalar_mul(p, q):
+    """
+    Multiply integers ``p`` and ``p`` modulo ``L``, where ``L`` is the
+    order of the main subgroup.
+
+    :param p: a :py:data:`.crypto_core_ed25519_SCALARBYTES`
+              long bytes sequence representing an integer
+    :type p: bytes
+    :param q: a :py:data:`.crypto_core_ed25519_SCALARBYTES`
+              long bytes sequence representing an integer
+    :type q: bytes
+    :return: an integer represented as a
+              :py:data:`.crypto_core_ed25519_SCALARBYTES` long bytes sequence
+    :rtype: bytes
+    """
+    ensure(isinstance(p, bytes) and isinstance(q, bytes) and
+           len(p) == crypto_core_ed25519_SCALARBYTES and
+           len(q) == crypto_core_ed25519_SCALARBYTES,
+           'Each scalar must be a {} long bytes sequence'.format(
+           'crypto_core_ed25519_SCALARBYTES'),
+           raising=exc.TypeError)
+
+    r = ffi.new("unsigned char[]", crypto_core_ed25519_SCALARBYTES)
+
+    lib.crypto_core_ed25519_scalar_mul(r, p, q)
+
+    return ffi.buffer(r, crypto_core_ed25519_SCALARBYTES)[:]
+
+
+def crypto_core_ed25519_scalar_reduce(s):
+    """
+    Reduce integer ``s`` to s modulo ``L``, where ``L`` is the order of
+    the main subgroup.
+
+    :param s: a :py:data:`.crypto_core_ed25519_NONREDUCEDSCALARBYTES`
+              long bytes sequence representing an integer
+    :type s: bytes
+    :return: an integer represented as a
+              :py:data:`.crypto_core_ed25519_SCALARBYTES` long bytes sequence
+    :rtype: bytes
+    """
+    ensure(isinstance(s, bytes) and
+           len(s) == crypto_core_ed25519_NONREDUCEDSCALARBYTES,
+           'Integer s must be a {} long bytes sequence'.format(
+           'crypto_core_ed25519_NONREDUCEDSCALARBYTES'),
+           raising=exc.TypeError)
+
+    r = ffi.new("unsigned char[]", crypto_core_ed25519_SCALARBYTES)
+
+    lib.crypto_core_ed25519_scalar_reduce(r, s)
+
+    return ffi.buffer(r, crypto_core_ed25519_SCALARBYTES)[:]

--- a/src/nacl/bindings/crypto_core.py
+++ b/src/nacl/bindings/crypto_core.py
@@ -191,7 +191,7 @@ def crypto_core_ed25519_scalar_complement(s):
 
 def crypto_core_ed25519_scalar_add(p, q):
     """
-    Add integers ``p`` and ``p`` modulo ``L``, where ``L`` is the order of
+    Add integers ``p`` and ``q`` modulo ``L``, where ``L`` is the order of
     the main subgroup.
 
     :param p: a :py:data:`.crypto_core_ed25519_SCALARBYTES`
@@ -220,7 +220,7 @@ def crypto_core_ed25519_scalar_add(p, q):
 
 def crypto_core_ed25519_scalar_sub(p, q):
     """
-    Subtract integers ``p`` and ``p`` modulo ``L``, where ``L`` is the
+    Subtract integers ``p`` and ``q`` modulo ``L``, where ``L`` is the
     order of the main subgroup.
 
     :param p: a :py:data:`.crypto_core_ed25519_SCALARBYTES`
@@ -249,7 +249,7 @@ def crypto_core_ed25519_scalar_sub(p, q):
 
 def crypto_core_ed25519_scalar_mul(p, q):
     """
-    Multiply integers ``p`` and ``p`` modulo ``L``, where ``L`` is the
+    Multiply integers ``p`` and ``q`` modulo ``L``, where ``L`` is the
     order of the main subgroup.
 
     :param p: a :py:data:`.crypto_core_ed25519_SCALARBYTES`
@@ -265,7 +265,7 @@ def crypto_core_ed25519_scalar_mul(p, q):
     ensure(isinstance(p, bytes) and isinstance(q, bytes) and
            len(p) == crypto_core_ed25519_SCALARBYTES and
            len(q) == crypto_core_ed25519_SCALARBYTES,
-           'Each scalar must be a {} long bytes sequence'.format(
+           'Each integer must be a {} long bytes sequence'.format(
            'crypto_core_ed25519_SCALARBYTES'),
            raising=exc.TypeError)
 
@@ -278,8 +278,8 @@ def crypto_core_ed25519_scalar_mul(p, q):
 
 def crypto_core_ed25519_scalar_reduce(s):
     """
-    Reduce integer ``s`` to s modulo ``L``, where ``L`` is the order of
-    the main subgroup.
+    Reduce integer ``s`` to ``s`` modulo ``L``, where ``L`` is the order
+    of the main subgroup.
 
     :param s: a :py:data:`.crypto_core_ed25519_NONREDUCEDSCALARBYTES`
               long bytes sequence representing an integer

--- a/src/nacl/bindings/crypto_scalarmult.py
+++ b/src/nacl/bindings/crypto_scalarmult.py
@@ -91,6 +91,34 @@ def crypto_scalarmult_ed25519_base(n):
     return ffi.buffer(q, crypto_scalarmult_ed25519_BYTES)[:]
 
 
+def crypto_scalarmult_ed25519_base_noclamp(n):
+    """
+    Computes and returns the scalar product of a standard group element and an
+    integer ``n`` on the edwards25519 curve. The integer ``n`` is not clamped.
+
+    :param n: a :py:data:`.crypto_scalarmult_ed25519_SCALARBYTES` long bytes
+              sequence representing a scalar
+    :type n: bytes
+    :return: a point on the edwards25519 curve, represented as a
+             :py:data:`.crypto_scalarmult_ed25519_BYTES` long bytes sequence
+    :rtype: bytes
+    """
+    ensure(isinstance(n, bytes) and
+           len(n) == crypto_scalarmult_ed25519_SCALARBYTES,
+           'Input must be a {} long bytes sequence'.format(
+           'crypto_scalarmult_ed25519_SCALARBYTES'),
+           raising=exc.TypeError)
+
+    q = ffi.new("unsigned char[]", crypto_scalarmult_ed25519_BYTES)
+
+    rc = lib.crypto_scalarmult_ed25519_base_noclamp(q, n)
+    ensure(rc == 0,
+           'Unexpected library error',
+           raising=exc.RuntimeError)
+
+    return ffi.buffer(q, crypto_scalarmult_ed25519_BYTES)[:]
+
+
 def crypto_scalarmult_ed25519(n, p):
     """
     Computes and returns the scalar product of a *clamped* integer ``n``
@@ -124,6 +152,44 @@ def crypto_scalarmult_ed25519(n, p):
     q = ffi.new("unsigned char[]", crypto_scalarmult_ed25519_BYTES)
 
     rc = lib.crypto_scalarmult_ed25519(q, n, p)
+    ensure(rc == 0,
+           'Unexpected library error',
+           raising=exc.RuntimeError)
+
+    return ffi.buffer(q, crypto_scalarmult_ed25519_BYTES)[:]
+
+
+def crypto_scalarmult_ed25519_noclamp(n, p):
+    """
+    Computes and returns the scalar product of an integer ``n``
+    and the given group element on the edwards25519 curve. The integer
+    ``n`` is not clamped.
+
+    :param n: a :py:data:`.crypto_scalarmult_ed25519_SCALARBYTES` long bytes
+              sequence representing a scalar
+    :type n: bytes
+    :param p: a :py:data:`.crypto_scalarmult_ed25519_BYTES` long bytes sequence
+              representing a point on the edwards25519 curve
+    :type p: bytes
+    :return: a point on the edwards25519 curve, represented as a
+             :py:data:`.crypto_scalarmult_ed25519_BYTES` long bytes sequence
+    :rtype: bytes
+    """
+    ensure(isinstance(n, bytes) and
+           len(n) == crypto_scalarmult_ed25519_SCALARBYTES,
+           'Input must be a {} long bytes sequence'.format(
+           'crypto_scalarmult_ed25519_SCALARBYTES'),
+           raising=exc.TypeError)
+
+    ensure(isinstance(p, bytes) and
+           len(p) == crypto_scalarmult_ed25519_BYTES,
+           'Input must be a {} long bytes sequence'.format(
+           'crypto_scalarmult_ed25519_BYTES'),
+           raising=exc.TypeError)
+
+    q = ffi.new("unsigned char[]", crypto_scalarmult_ed25519_BYTES)
+
+    rc = lib.crypto_scalarmult_ed25519_noclamp(q, n, p)
     ensure(rc == 0,
            'Unexpected library error',
            raising=exc.RuntimeError)

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -579,7 +579,8 @@ def test_scalarmult_ed25519_base():
 
 
 def test_scalarmult_ed25519_noclamp():
-    one = 32 * b'\x01'
+    # An arbitrary scalar which is known to differ once clamped
+    scalar = 32 * b'\x01'
     BASEPOINT = bytes(bytearray([0x58, 0x66, 0x66, 0x66,
                                  0x66, 0x66, 0x66, 0x66,
                                  0x66, 0x66, 0x66, 0x66,
@@ -591,20 +592,20 @@ def test_scalarmult_ed25519_noclamp():
                                 )
                       )
 
-    p = c.crypto_scalarmult_ed25519_noclamp(one, BASEPOINT)
-    pb = c.crypto_scalarmult_ed25519_base_noclamp(one)
-    pc = c.crypto_scalarmult_ed25519_base(one)
+    p = c.crypto_scalarmult_ed25519_noclamp(scalar, BASEPOINT)
+    pb = c.crypto_scalarmult_ed25519_base_noclamp(scalar)
+    pc = c.crypto_scalarmult_ed25519_base(scalar)
     assert p == pb
     assert pb != pc
 
     # clamp manually
-    ba = bytearray(one)
+    ba = bytearray(scalar)
     ba0 = bytes(bytearray([ba[0] & 248]))
     ba31 = bytes(bytearray([(ba[31] & 127) | 64]))
-    one_clamped = ba0 + bytes(ba[1:31]) + ba31
+    scalar_clamped = ba0 + bytes(ba[1:31]) + ba31
 
-    p1 = c.crypto_scalarmult_ed25519_noclamp(one_clamped, BASEPOINT)
-    p2 = c.crypto_scalarmult_ed25519(one, BASEPOINT)
+    p1 = c.crypto_scalarmult_ed25519_noclamp(scalar_clamped, BASEPOINT)
+    p2 = c.crypto_scalarmult_ed25519(scalar, BASEPOINT)
     assert p1 == p2
 
 


### PR DESCRIPTION
This PR depends on #527, it provides bindings to the new low-level ed25519 API that ship with libsodium 1.0.17 and forward: non-clamped curve point multiplication, and arithmetic modulo the order of the main subgroup.
