### PR TITLE
Fix build on Solaris

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ import os.path
 import platform
 import subprocess
 import sys
+from distutils.sysconfig import get_config_vars
 
 from setuptools import Distribution, setup
 from setuptools.command.build_ext import build_ext as _build_ext
@@ -129,9 +130,15 @@ class build_clib(_build_clib):
         if use_system():
             return
 
-        build_temp = os.path.abspath(self.build_temp)
+        # use Python's build environment variables
+        build_env = {key: val for key, val in
+                     get_config_vars().items() if key in
+                     ("LDFLAGS", "CFLAGS", "CC", "CCSHARED", "LDSHARED") and
+                     key not in os.environ}
+        os.environ.update(build_env)
 
         # Ensure our temporary build directory exists
+        build_temp = os.path.abspath(self.build_temp)
         try:
             os.makedirs(build_temp)
         except OSError as e:

--- a/setup.py
+++ b/setup.py
@@ -164,12 +164,16 @@ class build_clib(_build_clib):
         configure = abshere("src/libsodium/configure")
 
         # Run ./configure
+        configure_flags = ["--disable-shared", "--enable-static",
+                           "--disable-debug", "--disable-dependency-tracking",
+                           "--with-pic"]
+        if platform.system() == "SunOS":
+            # On Solaris, libssp doesn't link statically and causes linker
+            # errors during import
+            configure_flags.append("--disable-ssp")
         subprocess.check_call(
-            [
-                configure, "--disable-shared", "--enable-static",
-                "--disable-debug", "--disable-dependency-tracking",
-                "--with-pic", "--prefix", os.path.abspath(self.build_clib),
-            ],
+            [configure] + configure_flags +
+            ["--prefix", os.path.abspath(self.build_clib)],
             cwd=build_temp,
         )
 


### PR DESCRIPTION
This pull request fixes #502 (on Solaris, importing `nacl.bindings` fails with linker errors after building pynacl).
The changes handle two separate issues found:
1. The extension _sodium.so compiles with the flag `-m64` and the rest of the options that come from sysconfig, but libsodium itself does not use the same build configuration when compiling, so it is built as a 32-bit shared object which fails to link. To fix this I am including the build environment variables from sysconfig (those are used to build `_sodium.so`) to the environment variables used when building libsodium.
2. The second problem fixes the linking errors related to the stack guard:
`ImportError: ld.so.1: python2.7: fatal: relocation error: file /root/python/lib64/python2.7/site-packages/PyNaCl-1.3.0-py2.7-solaris-2.11-i86pc.64bit.egg/nacl/_sodium.so: symbol __stack_chk_guard: referenced symbol not found`.
This issue was also reported in #402 and #467.