### PR TITLE
test only py27/38 on mac

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -17,10 +17,6 @@ jobs:
         python.version: '2.7'
         TOXENV: py27
         MACOS_VERSION: '10.14'
-      Python34-macOS1014:
-        python.version: '3.4'
-        TOXENV: py34
-        MACOS_VERSION: '10.14'
       Python35-macOS1014:
         python.version: '3.5'
         TOXENV: py35


### PR DESCRIPTION
3.4 was removed from AP, but we don't need 3.4/3.5/3.6/3.7 tests on mac
since differences in Python will be caught by the rest of our CI