### PR TITLE
drop python 3.4 support

### DIFF
--- a/.azure-pipelines/wheel-builder.yml
+++ b/.azure-pipelines/wheel-builder.yml
@@ -12,7 +12,7 @@ jobs:
                   PYTHON_DOWNLOAD_URL: "https://www.python.org/ftp/python/2.7.16/python-2.7.16-macosx10.6.pkg"
                   PYTHON_BIN_PATH: /Library/Frameworks/Python.framework/Versions/2.7/bin/python
               Python3:
-                  python.version: '3.4'
+                  python.version: '3.5'
                   PYTHON_DOWNLOAD_URL: "https://www.python.org/ftp/python/3.7.3/python-3.7.3-macosx10.6.pkg"
                   PYTHON_BIN_PATH: /Library/Frameworks/Python.framework/Versions/3.7/bin/python3
       steps:
@@ -65,7 +65,7 @@ jobs:
               Python27mu:
                   PYTHON_VERSION: 'cp27-cp27mu'
               Python3m:
-                  PYTHON_VERSION: 'cp34-cp34m'
+                  PYTHON_VERSION: 'cp35-cp35m'
       steps:
           - script: /opt/python/$PYTHON_VERSION/bin/python -m virtualenv .venv
             displayName: Create virtualenv
@@ -108,16 +108,6 @@ jobs:
                   containerImage: 'pyca/cryptography-runner-windows:py27-x86_64'
                   SODIUM_LIB_PATH: 'C:/libsodium/x64/Release/v100/static'
                   PYTHON_VERSION: '27'
-                  WINDOWS_ARCH: 'x86_64'
-              Python34-x86:
-                  containerImage: 'pyca/cryptography-runner-windows:py34-x86'
-                  SODIUM_LIB_PATH: 'C:/libsodium/Win32/Release/v100/static'
-                  PYTHON_VERSION: '34'
-                  WINDOWS_ARCH: 'x86'
-              Python34-x86-64:
-                  containerImage: 'pyca/cryptography-runner-windows:py34-x86_64'
-                  SODIUM_LIB_PATH: 'C:/libsodium/x64/Release/v100/static'
-                  PYTHON_VERSION: '34'
                   WINDOWS_ARCH: 'x86_64'
               Python35-x86:
                   containerImage: 'pyca/cryptography-runner-windows:py35-x86'

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ matrix:
     include:
         - python: 2.7
           env: TOXENV=py27 SODIUM_INSTALL=bundled CC=gcc
-        - python: 3.4
-          env: TOXENV=py34 SODIUM_INSTALL=bundled CC=gcc
         - python: 3.5
           env: TOXENV=py35 SODIUM_INSTALL=bundled CC=gcc
         - python: 3.6
@@ -29,8 +27,6 @@ matrix:
         - env: TOXENV=pypy SODIUM_INSTALL=bundled CC=gcc
         - python: 2.7
           env: TOXENV=py27 SODIUM_INSTALL=system CC=gcc
-        - python: 3.4
-          env: TOXENV=py34 SODIUM_INSTALL=system CC=gcc
         - python: 3.5
           env: TOXENV=py35 SODIUM_INSTALL=system CC=gcc
         - python: 3.6
@@ -44,8 +40,6 @@ matrix:
         - env: TOXENV=pypy SODIUM_INSTALL=system CC=gcc
         - python: 2.7
           env: TOXENV=py27 SODIUM_INSTALL=bundled CC=clang
-        - python: 3.4
-          env: TOXENV=py34 SODIUM_INSTALL=bundled CC=clang
         - python: 3.5
           env: TOXENV=py35 SODIUM_INSTALL=bundled CC=clang
         - python: 3.6
@@ -59,8 +53,6 @@ matrix:
         - env: TOXENV=pypy SODIUM_INSTALL=bundled CC=clang
         - python: 2.7
           env: TOXENV=py27 SODIUM_INSTALL=system CC=clang
-        - python: 3.4
-          env: TOXENV=py34 SODIUM_INSTALL=system CC=clang
         - python: 3.5
           env: TOXENV=py35 SODIUM_INSTALL=system CC=clang
         - python: 3.6

--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,9 @@ Changelog
 * Update ``libsodium`` to 1.0.18.
 * **BACKWARDS INCOMPATIBLE:** We no longer distribute 32-bit ``manylinux1``
   wheels. Continuing to produce them was a maintenance burden.
+* Added support for Python 3.8.
+* Removed support for Python 3.4. This version is out of support from the
+  Python core team and is a significant maintenance burden in our CI.
 * Add low level bindings for extracting the seed and the public key
   from crypto_sign_ed25519 secret key
 * Add ``wheel`` and ``setuptools`` setup_requirements in ``setup.py`` (#485)

--- a/README.rst
+++ b/README.rst
@@ -18,7 +18,7 @@ PyNaCl: Python binding to the libsodium library
 
 PyNaCl is a Python binding to `libsodium`_, which is a fork of the
 `Networking and Cryptography library`_. These libraries have a stated goal of
-improving usability, security and speed. It supports Python 2.7 and 3.4+ as
+improving usability, security and speed. It supports Python 2.7 and 3.5+ as
 well as PyPy 2.6+.
 
 .. _libsodium: https://github.com/jedisct1/libsodium

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -60,16 +60,6 @@ jobs:
         containerImage: 'pyca/cryptography-runner-windows:py27-x86_64'
         PYTHON_DIR: 'Python27'
         SODIUM_LIB_PATH: 'C:/libsodium/x64/Release/v100/static'
-      Python34-x86:
-        TOXENV: py34
-        containerImage: 'pyca/cryptography-runner-windows:py34-x86'
-        PYTHON_DIR: 'Python34'
-        SODIUM_LIB_PATH: 'C:/libsodium/Win32/Release/v100/static'
-      Python34-x86_64:
-        TOXENV: py34
-        containerImage: 'pyca/cryptography-runner-windows:py34-x86_64'
-        PYTHON_DIR: 'Python34'
-        SODIUM_LIB_PATH: 'C:/libsodium/x64/Release/v100/static'
       Python35-x86:
         TOXENV: py35
         containerImage: 'pyca/cryptography-runner-windows:py35-x86'

--- a/setup.py
+++ b/setup.py
@@ -245,7 +245,6 @@ setup(
         "Programming Language :: Python :: 2",
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3",
-        "Programming Language :: Python :: 3.4",
         "Programming Language :: Python :: 3.5",
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = py27,pypy,py34,py35,py36,py37,py38,docs,meta
+envlist = py27,pypy,py35,py36,py37,py38,docs,meta
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
3.4 is not supported by the Python team, it's a very low % of our downloads, and keeping it functioning as dependencies begin dropping support is a maintenance burden.