### PR TITLE
Remove spurious requirement for wheel

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,6 +2,7 @@
 # Must be kept in sync with `setup_requirements` in `setup.py`
 requires = [
     "setuptools>=40.8.0",
+    "wheel",
     "cffi>=1.4.1; python_implementation != 'PyPy'",
 ]
 build-backend = "setuptools.build_meta"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,7 +2,6 @@
 # Must be kept in sync with `setup_requirements` in `setup.py`
 requires = [
     "setuptools>=40.8.0",
-    "wheel",
     "cffi>=1.4.1; python_implementation != 'PyPy'",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -35,8 +35,7 @@ except ImportError:
 
 
 requirements = ["six"]
-setup_requirements = ["setuptools",
-                      "wheel"]
+setup_requirements = ["setuptools"]
 test_requirements = ["pytest>=3.2.1,!=3.3.0",
                      "hypothesis>=3.27.0"]
 docs_requirements = ["sphinx>=1.6.5",


### PR DESCRIPTION
As discussed in https://github.com/pyca/pynacl/pull/485#issuecomment-634272864

Since #485 was about making setup.py match pyproject.toml, I changed it there too.