### PR TITLE
ARM64: Add ARM64 jobs in Travis-CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,6 +70,38 @@ matrix:
         - python: 3.6
           env: TOXENV=docs
         - env: TOXENV=meta
+        - python: 2.7
+          arch: arm64
+          env: TOXENV=py27 SODIUM_INSTALL=bundled CC=gcc
+        - python: 3.8
+          arch: arm64
+          env: TOXENV=py38 SODIUM_INSTALL=bundled CC=gcc
+          dist: xenial
+        - python: 2.7
+          arch: arm64
+          env: TOXENV=py27 SODIUM_INSTALL=system CC=gcc
+        - python: 3.8
+          arch: arm64
+          env: TOXENV=py38 SODIUM_INSTALL=system CC=gcc
+          dist: xenial
+        - python: 2.7
+          arch: arm64
+          env: TOXENV=py27 SODIUM_INSTALL=bundled CC=clang
+        - python: 3.8
+          arch: arm64
+          env: TOXENV=py38 SODIUM_INSTALL=bundled CC=clang
+          dist: xenial
+        - python: 2.7
+          arch: arm64
+          env: TOXENV=py27 SODIUM_INSTALL=system CC=clang
+        - python: 3.8
+          arch: arm64
+          env: TOXENV=py38 SODIUM_INSTALL=system CC=clang
+          dist: xenial
+        - python: 3.8
+          arch: arm64
+          env: TOXENV=py38 SODIUM_INSTALL=bundled SODIUM_INSTALL_MINIMAL=1 CC=gcc
+          dist: xenial
 
 install: .travis/install.sh
 


### PR DESCRIPTION
Updated travis.yml file to add ARM64 jobs in Travis-CI.
Added support for python3.6, python3.7 and python3.8 for ARM64 jobs.
Resolves the first step for : #601