### PR TITLE
Sort input file list

### DIFF
--- a/src/bindings/build.py
+++ b/src/bindings/build.py
@@ -23,13 +23,14 @@ from cffi import FFI
 __all__ = ["ffi"]
 
 
-HEADERS = glob.glob(
+# sort to negate indeterministic filesystem readdir order
+HEADERS = sorted(glob.glob(
     os.path.join(os.path.abspath(os.path.dirname(__file__)), "*.h")
-)
+))
 
-MINIMAL_HEADERS = glob.glob(
+MINIMAL_HEADERS = sorted(glob.glob(
     os.path.join(os.path.abspath(os.path.dirname(__file__)), "minimal", "*.h")
-)
+))
 
 
 # Build our FFI instance


### PR DESCRIPTION
Sort input file list
so that `nacl/_sodium.abi3.so` builds in a reproducible way
in spite of indeterministic filesystem readdir order
and http://bugs.python.org/issue30461

See https://reproducible-builds.org/ for why this is good.

This PR was done while working on reproducible builds for openSUSE.