### PR TITLE
deprecate 2.7 without breaking windows builders

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -4,6 +4,9 @@ Changelog
 1.5.0 (UNRELEASED)
 ------------------
 
+* Deprecated support for Python 2.7. Support for this version will be removed
+  in the next release.
+
 1.4.0 (2020-05-25)
 ------------------
 

--- a/src/nacl/__init__.py
+++ b/src/nacl/__init__.py
@@ -48,6 +48,6 @@ if sys.version_info[0] == 2:
         "Python 2 is no longer supported by the Python core team. Support for "
         "it is now deprecated in PyNaCl, and will be removed in the "
         "next release.",
-        UserWarning,
+        DeprecationWarning,
         stacklevel=2,
     )

--- a/src/nacl/__init__.py
+++ b/src/nacl/__init__.py
@@ -14,6 +14,9 @@
 
 from __future__ import absolute_import, division, print_function
 
+import sys
+import warnings
+
 __all__ = [
     "__title__",
     "__summary__",
@@ -38,3 +41,13 @@ __email__ = "cryptography-dev@python.org"
 
 __license__ = "Apache License 2.0"
 __copyright__ = "Copyright 2013-2018 {0}".format(__author__)
+
+
+if sys.version_info[0] == 2:
+    warnings.warn(
+        "Python 2 is no longer supported by the Python core team. Support for "
+        "it is now deprecated in PyNaCl, and will be removed in the "
+        "next release.",
+        UserWarning,
+        stacklevel=2,
+    )


### PR DESCRIPTION
This is exactly the same as the reverted commit and we should not merge this until we understand what happened.