### PR TITLE
make CI faster by passing parallel compile args

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,7 +30,7 @@ jobs:
       - name: Install tox and coverage
         run: pip install tox coverage
       - name: Run tests
-        run: tox
+        run: LIBSODIUM_MAKE_ARGS="-j$(sysctl -n hw.ncpu)" tox
         env:
           TOXENV: ${{ matrix.PYTHON.TOXENV }}
           SODIUM_INSTALL_MINIMAL: ${{ matrix.PYTHON.SODIUM_INSTALL_MINIMAL }}

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,27 +13,27 @@ branches:
 matrix:
     include:
         - python: 2.7
-          env: TOXENV=py27 SODIUM_INSTALL=bundled
+          env: TOXENV=py27 SODIUM_INSTALL=bundled LIBSODIUM_MAKE_ARGS="-j$(nproc)"
         - python: 3.5
-          env: TOXENV=py35 SODIUM_INSTALL=bundled
+          env: TOXENV=py35 SODIUM_INSTALL=bundled LIBSODIUM_MAKE_ARGS="-j$(nproc)"
         - python: 3.6
-          env: TOXENV=py36 SODIUM_INSTALL=bundled
+          env: TOXENV=py36 SODIUM_INSTALL=bundled LIBSODIUM_MAKE_ARGS="-j$(nproc)"
         - python: 3.7
-          env: TOXENV=py37 SODIUM_INSTALL=bundled
+          env: TOXENV=py37 SODIUM_INSTALL=bundled LIBSODIUM_MAKE_ARGS="-j$(nproc)"
         - python: 3.8
-          env: TOXENV=py38 SODIUM_INSTALL=bundled
+          env: TOXENV=py38 SODIUM_INSTALL=bundled LIBSODIUM_MAKE_ARGS="-j$(nproc)"
         - python: pypy2.7-7.3.1
-          env: TOXENV=pypy SODIUM_INSTALL=bundled
+          env: TOXENV=pypy SODIUM_INSTALL=bundled LIBSODIUM_MAKE_ARGS="-j$(nproc)"
         - python: 3.8
           env: TOXENV=py38 SODIUM_INSTALL=system
         - python: 3.8
-          env: TOXENV=py38 SODIUM_INSTALL=bundled SODIUM_INSTALL_MINIMAL=1
+          env: TOXENV=py38 SODIUM_INSTALL=bundled SODIUM_INSTALL_MINIMAL=1 LIBSODIUM_MAKE_ARGS="-j$(nproc)"
         - python: 3.8
-          env: TOXENV=docs
+          env: TOXENV=docs LIBSODIUM_MAKE_ARGS="-j$(nproc)"
         - python: 3.8
-          env: TOXENV=meta
+          env: TOXENV=meta LIBSODIUM_MAKE_ARGS="-j$(nproc)"
         - python: 3.8
-          env: TOXENV=py38 SODIUM_INSTALL=bundled
+          env: TOXENV=py38 SODIUM_INSTALL=bundled LIBSODIUM_MAKE_ARGS="-j$(nproc)"
           dist: focal
           arch: arm64-graviton2
           virt: lxd
@@ -45,7 +45,7 @@ matrix:
           virt: lxd
           group: edge
         - python: 3.8
-          env: TOXENV=py38 SODIUM_INSTALL=bundled SODIUM_INSTALL_MINIMAL=1
+          env: TOXENV=py38 SODIUM_INSTALL=bundled SODIUM_INSTALL_MINIMAL=1 LIBSODIUM_MAKE_ARGS="-j$(nproc)"
           dist: focal
           arch: arm64-graviton2
           virt: lxd

--- a/tox.ini
+++ b/tox.ini
@@ -8,7 +8,7 @@ extras =
 deps =
     coverage
     pretend
-passenv = SODIUM_INSTALL SODIUM_INSTALL_MINIMAL PYNACL_SODIUM_STATIC LIB INCLUDE
+passenv = SODIUM_INSTALL SODIUM_INSTALL_MINIMAL PYNACL_SODIUM_STATIC LIB INCLUDE LIBSODIUM_MAKE_ARGS
 commands =
     coverage run --parallel-mode -m pytest --capture=no --strict
     coverage combine


### PR DESCRIPTION
Relevant everywhere we compile from bundled libsodium (macOS, linux when SODIUM_INSTALL != system)