### PR TITLE
Move documentation of nacl.exceptions.ensure to correct file.

### DIFF
--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -1,6 +1,8 @@
 Exceptions
 ==========
 
+.. currentmodule:: nacl.exceptions
+
 All of the exceptions raised from PyNaCl-exposed methods/functions
 are subclasses of :py:exc:`nacl.exceptions.CryptoError`. This means
 downstream users can just wrap cryptographic operations inside a

--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -90,6 +90,7 @@ Utility functions for exception handling
     :type raising: exception
 
 Example usage:
+
 .. code-block:: python
 
     nacl.exceptions.ensure(

--- a/docs/exceptions.rst
+++ b/docs/exceptions.rst
@@ -70,3 +70,27 @@ standard library exception to :py:class:`~nacl.exceptions.CryptoError`.
 
     is a subclass of both CryptoError and standard library's
     ValueError
+
+
+Utility functions for exception handling
+----------------------------------------
+
+.. function:: ensure(cond, *args, raising=nacl.exceptions.AssertionError)
+
+    Returns if a condition is true, otherwise raise a caller-configurable
+    :py:class:`Exception`
+
+    :param cond: the condition to be checked
+    :type cond: bool
+    :param sequence args: the arguments to be passed to the exception's
+                          constructor
+    :param raising: the exception to be raised if `cond` is `False`
+    :type raising: exception
+
+Example usage:
+.. code-block:: python
+
+    nacl.exceptions.ensure(
+        a == 1 or a == 2,
+        "a must be either 1 or 2"
+    )

--- a/docs/utils.rst
+++ b/docs/utils.rst
@@ -36,15 +36,3 @@ Utilities
     :param encoder: The encoder class used to encode the produced bytes.
     :return bytes: The random bytestring.
 
-.. function:: ensure(cond, *args, raising=nacl.exceptions.AssertionError)
-
-    Returns if a condition is true, otherwise raise a caller-configurable
-    :py:class:`Exception`
-
-    :param cond: the condition to be checked
-    :type cond: bool
-    :param sequence args: the arguments to be passed to the exception's
-                          constructor
-    :param raising: the exception to be raised if `cond` is `False`
-    :type raising: exception
-


### PR DESCRIPTION
The documentation for `ensure` was in the file utils.rst, but the function is part of the `nacl.exceptions` module.

I've also added an example to the docs.

~Note: I have not yet tried actually building the docs, so I hope I didn't break anything.~ I figured out how to build the docs and fixed my Syntax error