### PR TITLE
Add type annotations to `nacl`

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -216,6 +216,7 @@ setup(
     tests_require=test_requirements,
     package_dir={"": "src"},
     packages=["nacl", "nacl.pwhash", "nacl.bindings"],
+    package_data = {"nacl": ["py.typed"]},
     ext_package="nacl",
     cffi_modules=["src/bindings/build.py:ffi"],
     cmdclass={"build_clib": build_clib, "build_ext": build_ext},

--- a/setup.py
+++ b/setup.py
@@ -216,7 +216,7 @@ setup(
     tests_require=test_requirements,
     package_dir={"": "src"},
     packages=["nacl", "nacl.pwhash", "nacl.bindings"],
-    package_data = {"nacl": ["py.typed"]},
+    package_data={"nacl": ["py.typed"]},
     ext_package="nacl",
     cffi_modules=["src/bindings/build.py:ffi"],
     cmdclass={"build_clib": build_clib, "build_ext": build_ext},

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ except ImportError:
     from distutils.command.build_clib import build_clib as _build_clib
 
 
-requirements = []
+requirements = ["typing_extensions"]
 setup_requirements = ["setuptools"]
 test_requirements = ["pytest>=3.2.1,!=3.3.0", "hypothesis>=3.27.0"]
 docs_requirements = ["sphinx>=1.6.5", "sphinx_rtd_theme"]

--- a/src/nacl/bindings/crypto_aead.py
+++ b/src/nacl/bindings/crypto_aead.py
@@ -6,11 +6,6 @@
 #
 # http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by applicable law or agreed to in writing, software
-# distributed under the License is distributed on an "AS IS" BASIS,
-# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-# See the License for the specific language governing permissions and
-# limitations under the License.
 
 
 from nacl import exceptions as exc
@@ -82,7 +77,9 @@ _aead_xchacha20poly1305_ietf_CRYPTBYTES_MAX = (
 )
 
 
-def crypto_aead_chacha20poly1305_ietf_encrypt(message, aad, nonce, key):
+def crypto_aead_chacha20poly1305_ietf_encrypt(
+    message: bytes, aad: bytes, nonce: bytes, key: bytes
+) -> bytes:
     """
     Encrypt the given ``message`` using the IETF ratified chacha20poly1305
     construction described in RFC7539.
@@ -159,7 +156,9 @@ def crypto_aead_chacha20poly1305_ietf_encrypt(message, aad, nonce, key):
     return ffi.buffer(ciphertext, clen[0])[:]
 
 
-def crypto_aead_chacha20poly1305_ietf_decrypt(ciphertext, aad, nonce, key):
+def crypto_aead_chacha20poly1305_ietf_decrypt(
+    ciphertext: bytes, aad: bytes, nonce: bytes, key: bytes
+) -> bytes:
     """
     Decrypt the given ``ciphertext`` using the IETF ratified chacha20poly1305
     construction described in RFC7539.
@@ -236,7 +235,9 @@ def crypto_aead_chacha20poly1305_ietf_decrypt(ciphertext, aad, nonce, key):
     return ffi.buffer(message, mlen[0])[:]
 
 
-def crypto_aead_chacha20poly1305_encrypt(message, aad, nonce, key):
+def crypto_aead_chacha20poly1305_encrypt(
+    message: bytes, aad: bytes, nonce: bytes, key: bytes
+) -> bytes:
     """
     Encrypt the given ``message`` using the "legacy" construction
     described in draft-agl-tls-chacha20poly1305.
@@ -314,7 +315,9 @@ def crypto_aead_chacha20poly1305_encrypt(message, aad, nonce, key):
     return ffi.buffer(ciphertext, clen[0])[:]
 
 
-def crypto_aead_chacha20poly1305_decrypt(ciphertext, aad, nonce, key):
+def crypto_aead_chacha20poly1305_decrypt(
+    ciphertext: bytes, aad: bytes, nonce: bytes, key: bytes
+) -> bytes:
     """
     Decrypt the given ``ciphertext`` using the "legacy" construction
     described in draft-agl-tls-chacha20poly1305.
@@ -391,7 +394,9 @@ def crypto_aead_chacha20poly1305_decrypt(ciphertext, aad, nonce, key):
     return ffi.buffer(message, mlen[0])[:]
 
 
-def crypto_aead_xchacha20poly1305_ietf_encrypt(message, aad, nonce, key):
+def crypto_aead_xchacha20poly1305_ietf_encrypt(
+    message: bytes, aad: bytes, nonce: bytes, key: bytes
+) -> bytes:
     """
     Encrypt the given ``message`` using the long-nonces xchacha20poly1305
     construction.
@@ -469,7 +474,9 @@ def crypto_aead_xchacha20poly1305_ietf_encrypt(message, aad, nonce, key):
     return ffi.buffer(ciphertext, clen[0])[:]
 
 
-def crypto_aead_xchacha20poly1305_ietf_decrypt(ciphertext, aad, nonce, key):
+def crypto_aead_xchacha20poly1305_ietf_decrypt(
+    ciphertext: bytes, aad: bytes, nonce: bytes, key: bytes
+) -> bytes:
     """
     Decrypt the given ``ciphertext`` using the long-nonces xchacha20poly1305
     construction.

--- a/src/nacl/bindings/crypto_box.py
+++ b/src/nacl/bindings/crypto_box.py
@@ -196,7 +196,9 @@ def crypto_box_afternm(message: bytes, nonce: bytes, k: bytes) -> bytes:
     return ffi.buffer(ciphertext, len(padded))[crypto_box_BOXZEROBYTES:]
 
 
-def crypto_box_open_afternm(ciphertext: bytes, nonce: bytes, k: bytes) -> bytes:
+def crypto_box_open_afternm(
+    ciphertext: bytes, nonce: bytes, k: bytes
+) -> bytes:
     """
     Decrypts and returns the encrypted message ``ciphertext``, using the shared
     key ``k`` and the nonce ``nonce``.

--- a/src/nacl/bindings/crypto_box.py
+++ b/src/nacl/bindings/crypto_box.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from typing import Tuple
 
 from nacl import exceptions as exc
 from nacl._sodium import ffi, lib
@@ -31,7 +31,7 @@ crypto_box_BEFORENMBYTES = lib.crypto_box_beforenmbytes()
 crypto_box_SEALBYTES = lib.crypto_box_sealbytes()
 
 
-def crypto_box_keypair():
+def crypto_box_keypair() -> Tuple[bytes, bytes]:
     """
     Returns a randomly generated public and secret key.
 
@@ -49,7 +49,7 @@ def crypto_box_keypair():
     )
 
 
-def crypto_box_seed_keypair(seed):
+def crypto_box_seed_keypair(seed: bytes) -> Tuple[bytes, bytes]:
     """
     Returns a (public, secret) keypair deterministically generated
     from an input ``seed``.
@@ -83,7 +83,7 @@ def crypto_box_seed_keypair(seed):
     )
 
 
-def crypto_box(message, nonce, pk, sk):
+def crypto_box(message: bytes, nonce: bytes, pk: bytes, sk: bytes) -> bytes:
     """
     Encrypts and returns a message ``message`` using the secret key ``sk``,
     public key ``pk``, and the nonce ``nonce``.
@@ -112,7 +112,9 @@ def crypto_box(message, nonce, pk, sk):
     return ffi.buffer(ciphertext, len(padded))[crypto_box_BOXZEROBYTES:]
 
 
-def crypto_box_open(ciphertext, nonce, pk, sk):
+def crypto_box_open(
+    ciphertext: bytes, nonce: bytes, pk: bytes, sk: bytes
+) -> bytes:
     """
     Decrypts and returns an encrypted message ``ciphertext``, using the secret
     key ``sk``, public key ``pk``, and the nonce ``nonce``.
@@ -145,7 +147,7 @@ def crypto_box_open(ciphertext, nonce, pk, sk):
     return ffi.buffer(plaintext, len(padded))[crypto_box_ZEROBYTES:]
 
 
-def crypto_box_beforenm(pk, sk):
+def crypto_box_beforenm(pk: bytes, sk: bytes) -> bytes:
     """
     Computes and returns the shared key for the public key ``pk`` and the
     secret key ``sk``. This can be used to speed up operations where the same
@@ -169,7 +171,7 @@ def crypto_box_beforenm(pk, sk):
     return ffi.buffer(k, crypto_box_BEFORENMBYTES)[:]
 
 
-def crypto_box_afternm(message, nonce, k):
+def crypto_box_afternm(message: bytes, nonce: bytes, k: bytes) -> bytes:
     """
     Encrypts and returns the message ``message`` using the shared key ``k`` and
     the nonce ``nonce``.
@@ -194,7 +196,7 @@ def crypto_box_afternm(message, nonce, k):
     return ffi.buffer(ciphertext, len(padded))[crypto_box_BOXZEROBYTES:]
 
 
-def crypto_box_open_afternm(ciphertext, nonce, k):
+def crypto_box_open_afternm(ciphertext: bytes, nonce: bytes, k: bytes) -> bytes:
     """
     Decrypts and returns the encrypted message ``ciphertext``, using the shared
     key ``k`` and the nonce ``nonce``.
@@ -223,7 +225,7 @@ def crypto_box_open_afternm(ciphertext, nonce, k):
     return ffi.buffer(plaintext, len(padded))[crypto_box_ZEROBYTES:]
 
 
-def crypto_box_seal(message, pk):
+def crypto_box_seal(message: bytes, pk: bytes) -> bytes:
     """
     Encrypts and returns a message ``message`` using an ephemeral secret key
     and the public key ``pk``.
@@ -261,7 +263,7 @@ def crypto_box_seal(message, pk):
     return ffi.buffer(ciphertext, _clen)[:]
 
 
-def crypto_box_seal_open(ciphertext, pk, sk):
+def crypto_box_seal_open(ciphertext: bytes, pk: bytes, sk: bytes) -> bytes:
     """
     Decrypts and returns an encrypted message ``ciphertext``, using the
     recipent's secret key ``sk`` and the sender's ephemeral public key

--- a/src/nacl/bindings/crypto_core.py
+++ b/src/nacl/bindings/crypto_core.py
@@ -32,7 +32,7 @@ if has_crypto_core_ed25519:
     )
 
 
-def crypto_core_ed25519_is_valid_point(p):
+def crypto_core_ed25519_is_valid_point(p: bytes) -> bool:
     """
     Check if ``p`` represents a point on the edwards25519 curve, in canonical
     form, on the main subgroup, and that the point doesn't have a small order.
@@ -61,7 +61,7 @@ def crypto_core_ed25519_is_valid_point(p):
     return rc == 1
 
 
-def crypto_core_ed25519_add(p, q):
+def crypto_core_ed25519_add(p: bytes, q: bytes) -> bytes:
     """
     Add two points on the edwards25519 curve.
 
@@ -102,7 +102,7 @@ def crypto_core_ed25519_add(p, q):
     return ffi.buffer(r, crypto_core_ed25519_BYTES)[:]
 
 
-def crypto_core_ed25519_sub(p, q):
+def crypto_core_ed25519_sub(p: bytes, q: bytes) -> bytes:
     """
     Subtract a point from another on the edwards25519 curve.
 
@@ -143,7 +143,7 @@ def crypto_core_ed25519_sub(p, q):
     return ffi.buffer(r, crypto_core_ed25519_BYTES)[:]
 
 
-def crypto_core_ed25519_scalar_invert(s):
+def crypto_core_ed25519_scalar_invert(s: bytes) -> bytes:
     """
     Return the multiplicative inverse of integer ``s`` modulo ``L``,
     i.e an integer ``i`` such that ``s * i = 1 (mod L)``, where ``L``
@@ -182,7 +182,7 @@ def crypto_core_ed25519_scalar_invert(s):
     return ffi.buffer(r, crypto_core_ed25519_SCALARBYTES)[:]
 
 
-def crypto_core_ed25519_scalar_negate(s):
+def crypto_core_ed25519_scalar_negate(s: bytes) -> bytes:
     """
     Return the integer ``n`` such that ``s + n = 0 (mod L)``, where ``L``
     is the order of the main subgroup.
@@ -217,7 +217,7 @@ def crypto_core_ed25519_scalar_negate(s):
     return ffi.buffer(r, crypto_core_ed25519_SCALARBYTES)[:]
 
 
-def crypto_core_ed25519_scalar_complement(s):
+def crypto_core_ed25519_scalar_complement(s: bytes) -> bytes:
     """
     Return the complement of integer ``s`` modulo ``L``, i.e. an integer
     ``c`` such that ``s + c = 1 (mod L)``, where ``L`` is the order of
@@ -253,7 +253,7 @@ def crypto_core_ed25519_scalar_complement(s):
     return ffi.buffer(r, crypto_core_ed25519_SCALARBYTES)[:]
 
 
-def crypto_core_ed25519_scalar_add(p, q):
+def crypto_core_ed25519_scalar_add(p: bytes, q: bytes) -> bytes:
     """
     Add integers ``p`` and ``q`` modulo ``L``, where ``L`` is the order of
     the main subgroup.
@@ -294,7 +294,7 @@ def crypto_core_ed25519_scalar_add(p, q):
     return ffi.buffer(r, crypto_core_ed25519_SCALARBYTES)[:]
 
 
-def crypto_core_ed25519_scalar_sub(p, q):
+def crypto_core_ed25519_scalar_sub(p: bytes, q: bytes) -> bytes:
     """
     Subtract integers ``p`` and ``q`` modulo ``L``, where ``L`` is the
     order of the main subgroup.
@@ -335,7 +335,7 @@ def crypto_core_ed25519_scalar_sub(p, q):
     return ffi.buffer(r, crypto_core_ed25519_SCALARBYTES)[:]
 
 
-def crypto_core_ed25519_scalar_mul(p, q):
+def crypto_core_ed25519_scalar_mul(p: bytes, q: bytes) -> bytes:
     """
     Multiply integers ``p`` and ``q`` modulo ``L``, where ``L`` is the
     order of the main subgroup.
@@ -376,7 +376,7 @@ def crypto_core_ed25519_scalar_mul(p, q):
     return ffi.buffer(r, crypto_core_ed25519_SCALARBYTES)[:]
 
 
-def crypto_core_ed25519_scalar_reduce(s):
+def crypto_core_ed25519_scalar_reduce(s: bytes) -> bytes:
     """
     Reduce integer ``s`` to ``s`` modulo ``L``, where ``L`` is the order
     of the main subgroup.

--- a/src/nacl/bindings/crypto_generichash.py
+++ b/src/nacl/bindings/crypto_generichash.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from typing import NoReturn
 
 from nacl import exceptions as exc
 from nacl._sodium import ffi, lib
@@ -34,7 +34,9 @@ _OVERLONG = "{0} length greater than {1} bytes"
 _TOOBIG = "{0} greater than {1}"
 
 
-def _checkparams(digest_size, key, salt, person):
+def _checkparams(
+    digest_size: int, key: bytes, salt: bytes, person: bytes
+) -> None:
     """Check hash parameters"""
     ensure(
         isinstance(key, bytes),
@@ -86,11 +88,16 @@ def _checkparams(digest_size, key, salt, person):
 
 
 def generichash_blake2b_salt_personal(
-    data, digest_size=crypto_generichash_BYTES, key=b"", salt=b"", person=b""
-):
+    data: bytes,
+    digest_size: int = crypto_generichash_BYTES,
+    key: bytes = b"",
+    salt: bytes = b"",
+    person: bytes = b"",
+) -> bytes:
     """One shot hash interface
 
     :param data: the input data to the hash function
+    :type data: bytes
     :param digest_size: must be at most
                         :py:data:`.crypto_generichash_BYTES_MAX`;
                         the default digest size is
@@ -143,13 +150,13 @@ class Blake2State:
 
     __slots__ = ["_statebuf", "digest_size"]
 
-    def __init__(self, digest_size):
+    def __init__(self, digest_size: int):
         self._statebuf = ffi.new(
             "unsigned char[]", crypto_generichash_STATEBYTES
         )
         self.digest_size = digest_size
 
-    def __reduce__(self):
+    def __reduce__(self) -> NoReturn:
         """
         Raise the same exception as hashlib's blake implementation
         on copy.copy()
@@ -158,7 +165,7 @@ class Blake2State:
             "can't pickle {} objects".format(self.__class__.__name__)
         )
 
-    def copy(self):
+    def copy(self) -> "Blake2State":
         _st = self.__class__(self.digest_size)
         ffi.memmove(
             _st._statebuf, self._statebuf, crypto_generichash_STATEBYTES
@@ -167,8 +174,11 @@ class Blake2State:
 
 
 def generichash_blake2b_init(
-    key=b"", salt=b"", person=b"", digest_size=crypto_generichash_BYTES
-):
+    key: bytes = b"",
+    salt: bytes = b"",
+    person: bytes = b"",
+    digest_size: int = crypto_generichash_BYTES,
+) -> Blake2State:
     """
     Create a new initialized blake2b hash state
 
@@ -211,7 +221,7 @@ def generichash_blake2b_init(
     return state
 
 
-def generichash_blake2b_update(state, data):
+def generichash_blake2b_update(state: Blake2State, data: bytes) -> None:
     """Update the blake2b hash state
 
     :param state: a initialized Blake2bState object as returned from
@@ -239,7 +249,7 @@ def generichash_blake2b_update(state, data):
     ensure(rc == 0, "Unexpected failure", raising=exc.RuntimeError)
 
 
-def generichash_blake2b_final(state):
+def generichash_blake2b_final(state: Blake2State) -> bytes:
     """Finalize the blake2b hash state and return the digest.
 
     :param state: a initialized Blake2bState object as returned from

--- a/src/nacl/bindings/crypto_hash.py
+++ b/src/nacl/bindings/crypto_hash.py
@@ -24,7 +24,7 @@ crypto_hash_sha256_BYTES = lib.crypto_hash_sha256_bytes()
 crypto_hash_sha512_BYTES = lib.crypto_hash_sha512_bytes()
 
 
-def crypto_hash(message):
+def crypto_hash(message: bytes) -> bytes:
     """
     Hashes and returns the message ``message``.
 
@@ -37,7 +37,7 @@ def crypto_hash(message):
     return ffi.buffer(digest, crypto_hash_BYTES)[:]
 
 
-def crypto_hash_sha256(message):
+def crypto_hash_sha256(message: bytes) -> bytes:
     """
     Hashes and returns the message ``message``.
 
@@ -50,7 +50,7 @@ def crypto_hash_sha256(message):
     return ffi.buffer(digest, crypto_hash_sha256_BYTES)[:]
 
 
-def crypto_hash_sha512(message):
+def crypto_hash_sha512(message: bytes) -> bytes:
     """
     Hashes and returns the message ``message``.
 

--- a/src/nacl/bindings/crypto_kx.py
+++ b/src/nacl/bindings/crypto_kx.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from typing import Tuple
 
 from nacl import exceptions as exc
 from nacl._sodium import ffi, lib
@@ -36,7 +36,7 @@ crypto_kx_SEED_BYTES = lib.crypto_kx_seedbytes()
 crypto_kx_SESSION_KEY_BYTES = lib.crypto_kx_sessionkeybytes()
 
 
-def crypto_kx_keypair():
+def crypto_kx_keypair() -> Tuple[bytes, bytes]:
     """
     Generate a keypair.
     This is a duplicate crypto_box_keypair, but
@@ -55,7 +55,7 @@ def crypto_kx_keypair():
     )
 
 
-def crypto_kx_seed_keypair(seed):
+def crypto_kx_seed_keypair(seed: bytes) -> Tuple[bytes, bytes]:
     """
     Generate a keypair with a given seed.
     This is functionally the same as crypto_box_seed_keypair, however
@@ -85,8 +85,10 @@ def crypto_kx_seed_keypair(seed):
 
 
 def crypto_kx_client_session_keys(
-    client_public_key, client_secret_key, server_public_key
-):
+    client_public_key: bytes,
+    client_secret_key: bytes,
+    server_public_key: bytes,
+) -> Tuple[bytes, bytes]:
     """
     Generate session keys for the client.
     :param client_public_key:
@@ -141,8 +143,10 @@ def crypto_kx_client_session_keys(
 
 
 def crypto_kx_server_session_keys(
-    server_public_key, server_secret_key, client_public_key
-):
+    server_public_key: bytes,
+    server_secret_key: bytes,
+    client_public_key: bytes,
+) -> Tuple[bytes, bytes]:
     """
     Generate session keys for the server.
     :param server_public_key:

--- a/src/nacl/bindings/crypto_pwhash.py
+++ b/src/nacl/bindings/crypto_pwhash.py
@@ -216,7 +216,7 @@ def _check_memory_occupation(
 
 def nacl_bindings_pick_scrypt_params(
     opslimit: int, memlimit: int
-)-> Tuple[int, int, int]:
+) -> Tuple[int, int, int]:
     """Python implementation of libsodium's pickparams"""
 
     if opslimit < 32768:

--- a/src/nacl/bindings/crypto_pwhash.py
+++ b/src/nacl/bindings/crypto_pwhash.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import sys
+from typing import Tuple
 
 import nacl.exceptions as exc
 from nacl._sodium import ffi, lib
@@ -171,7 +172,9 @@ UINT64_MAX = (1 << 64) - 1
 SCRYPT_MAX_MEM = 32 * (1024 * 1024)
 
 
-def _check_memory_occupation(n, r, p, maxmem=SCRYPT_MAX_MEM):
+def _check_memory_occupation(
+    n: int, r: int, p: int, maxmem: int = SCRYPT_MAX_MEM
+) -> None:
     ensure(r != 0, "Invalid block size", raising=exc.ValueError)
 
     ensure(p != 0, "Invalid parallelization factor", raising=exc.ValueError)
@@ -211,7 +214,9 @@ def _check_memory_occupation(n, r, p, maxmem=SCRYPT_MAX_MEM):
     )
 
 
-def nacl_bindings_pick_scrypt_params(opslimit, memlimit):
+def nacl_bindings_pick_scrypt_params(
+    opslimit: int, memlimit: int
+)-> Tuple[int, int, int]:
     """Python implementation of libsodium's pickparams"""
 
     if opslimit < 32768:
@@ -242,8 +247,14 @@ def nacl_bindings_pick_scrypt_params(opslimit, memlimit):
 
 
 def crypto_pwhash_scryptsalsa208sha256_ll(
-    passwd, salt, n, r, p, dklen=64, maxmem=SCRYPT_MAX_MEM
-):
+    passwd: bytes,
+    salt: bytes,
+    n: int,
+    r: int,
+    p: int,
+    dklen: int = 64,
+    maxmem: int = SCRYPT_MAX_MEM,
+) -> bytes:
     """
     Derive a cryptographic key using the ``passwd`` and ``salt``
     given as input.
@@ -296,10 +307,10 @@ def crypto_pwhash_scryptsalsa208sha256_ll(
 
 
 def crypto_pwhash_scryptsalsa208sha256_str(
-    passwd,
-    opslimit=SCRYPT_OPSLIMIT_INTERACTIVE,
-    memlimit=SCRYPT_MEMLIMIT_INTERACTIVE,
-):
+    passwd: bytes,
+    opslimit: int = SCRYPT_OPSLIMIT_INTERACTIVE,
+    memlimit: int = SCRYPT_MEMLIMIT_INTERACTIVE,
+) -> bytes:
     """
     Derive a cryptographic key using the ``passwd`` and ``salt``
     given as input, returning a string representation which includes
@@ -339,7 +350,10 @@ def crypto_pwhash_scryptsalsa208sha256_str(
     return ffi.string(buf)
 
 
-def crypto_pwhash_scryptsalsa208sha256_str_verify(passwd_hash, passwd):
+def crypto_pwhash_scryptsalsa208sha256_str_verify(
+    passwd_hash: bytes,
+    passwd: bytes
+) -> bool:
     """
     Verifies the ``passwd`` against the ``passwd_hash`` that was generated.
     Returns True or False depending on the success
@@ -370,7 +384,7 @@ def crypto_pwhash_scryptsalsa208sha256_str_verify(passwd_hash, passwd):
     return True
 
 
-def _check_argon2_limits_alg(opslimit, memlimit, alg):
+def _check_argon2_limits_alg(opslimit: int, memlimit: int, alg: int) -> None:
 
     if alg == crypto_pwhash_ALG_ARGON2I13:
         if memlimit < crypto_pwhash_argon2i_MEMLIMIT_MIN:
@@ -427,7 +441,14 @@ def _check_argon2_limits_alg(opslimit, memlimit, alg):
         raise exc.TypeError("Unsupported algorithm")
 
 
-def crypto_pwhash_alg(outlen, passwd, salt, opslimit, memlimit, alg):
+def crypto_pwhash_alg(
+    outlen: int,
+    passwd: bytes,
+    salt: bytes,
+    opslimit: int,
+    memlimit: int,
+    alg: int
+) -> bytes:
     """
     Derive a raw cryptographic key using the ``passwd`` and the ``salt``
     given as input to the ``alg`` algorithm.
@@ -436,6 +457,8 @@ def crypto_pwhash_alg(outlen, passwd, salt, opslimit, memlimit, alg):
     :type outlen: int
     :param passwd: The input password
     :type passwd: bytes
+    :param salt:
+    :type salt: bytes
     :param opslimit: computational cost
     :type opslimit: int
     :param memlimit: memory cost
@@ -489,10 +512,15 @@ def crypto_pwhash_alg(outlen, passwd, salt, opslimit, memlimit, alg):
     return ffi.buffer(outbuf, outlen)[:]
 
 
-def crypto_pwhash_str_alg(passwd, opslimit, memlimit, alg):
+def crypto_pwhash_str_alg(
+    passwd: bytes,
+    opslimit: int,
+    memlimit: int,
+    alg: int,
+) -> bytes:
     """
     Derive a cryptographic key using the ``passwd`` given as input
-    and a random ``salt``, returning a string representation which
+    and a random salt, returning a string representation which
     includes the salt, the tuning parameters and the used algorithm.
 
     :param passwd: The input password
@@ -527,7 +555,7 @@ def crypto_pwhash_str_alg(passwd, opslimit, memlimit, alg):
     return ffi.string(outbuf)
 
 
-def crypto_pwhash_str_verify(passwd_hash, passwd):
+def crypto_pwhash_str_verify(passwd_hash: bytes, passwd: bytes) -> bool:
     """
     Verifies the ``passwd`` against a given password hash.
 

--- a/src/nacl/bindings/crypto_pwhash.py
+++ b/src/nacl/bindings/crypto_pwhash.py
@@ -351,8 +351,7 @@ def crypto_pwhash_scryptsalsa208sha256_str(
 
 
 def crypto_pwhash_scryptsalsa208sha256_str_verify(
-    passwd_hash: bytes,
-    passwd: bytes
+    passwd_hash: bytes, passwd: bytes
 ) -> bool:
     """
     Verifies the ``passwd`` against the ``passwd_hash`` that was generated.
@@ -447,7 +446,7 @@ def crypto_pwhash_alg(
     salt: bytes,
     opslimit: int,
     memlimit: int,
-    alg: int
+    alg: int,
 ) -> bytes:
     """
     Derive a raw cryptographic key using the ``passwd`` and the ``salt``

--- a/src/nacl/bindings/crypto_scalarmult.py
+++ b/src/nacl/bindings/crypto_scalarmult.py
@@ -33,7 +33,7 @@ if has_crypto_scalarmult_ed25519:
     )
 
 
-def crypto_scalarmult_base(n):
+def crypto_scalarmult_base(n: bytes) -> bytes:
     """
     Computes and returns the scalar product of a standard group element and an
     integer ``n``.
@@ -49,7 +49,7 @@ def crypto_scalarmult_base(n):
     return ffi.buffer(q, crypto_scalarmult_SCALARBYTES)[:]
 
 
-def crypto_scalarmult(n, p):
+def crypto_scalarmult(n: bytes, p: bytes) -> bytes:
     """
     Computes and returns the scalar product of the given group element and an
     integer ``n``.
@@ -66,7 +66,7 @@ def crypto_scalarmult(n, p):
     return ffi.buffer(q, crypto_scalarmult_SCALARBYTES)[:]
 
 
-def crypto_scalarmult_ed25519_base(n):
+def crypto_scalarmult_ed25519_base(n: bytes) -> bytes:
     """
     Computes and returns the scalar product of a standard group element and an
     integer ``n`` on the edwards25519 curve.
@@ -103,7 +103,7 @@ def crypto_scalarmult_ed25519_base(n):
     return ffi.buffer(q, crypto_scalarmult_ed25519_BYTES)[:]
 
 
-def crypto_scalarmult_ed25519_base_noclamp(n):
+def crypto_scalarmult_ed25519_base_noclamp(n: bytes) -> bytes:
     """
     Computes and returns the scalar product of a standard group element and an
     integer ``n`` on the edwards25519 curve. The integer ``n`` is not clamped.
@@ -140,7 +140,7 @@ def crypto_scalarmult_ed25519_base_noclamp(n):
     return ffi.buffer(q, crypto_scalarmult_ed25519_BYTES)[:]
 
 
-def crypto_scalarmult_ed25519(n, p):
+def crypto_scalarmult_ed25519(n: bytes, p: bytes) -> bytes:
     """
     Computes and returns the scalar product of a *clamped* integer ``n``
     and the given group element on the edwards25519 curve.
@@ -191,7 +191,7 @@ def crypto_scalarmult_ed25519(n, p):
     return ffi.buffer(q, crypto_scalarmult_ed25519_BYTES)[:]
 
 
-def crypto_scalarmult_ed25519_noclamp(n, p):
+def crypto_scalarmult_ed25519_noclamp(n: bytes, p: bytes) -> bytes:
     """
     Computes and returns the scalar product of an integer ``n``
     and the given group element on the edwards25519 curve. The integer

--- a/src/nacl/bindings/crypto_secretbox.py
+++ b/src/nacl/bindings/crypto_secretbox.py
@@ -52,7 +52,9 @@ def crypto_secretbox(message: bytes, nonce: bytes, key: bytes) -> bytes:
     return ciphertext[crypto_secretbox_BOXZEROBYTES:]
 
 
-def crypto_secretbox_open(ciphertext: bytes, nonce: bytes, key: bytes) -> bytes:
+def crypto_secretbox_open(
+    ciphertext: bytes, nonce: bytes, key: bytes
+) -> bytes:
     """
     Decrypt and returns the encrypted message ``ciphertext`` with the secret
     ``key`` and the nonce ``nonce``.

--- a/src/nacl/bindings/crypto_secretbox.py
+++ b/src/nacl/bindings/crypto_secretbox.py
@@ -26,7 +26,7 @@ crypto_secretbox_MACBYTES = lib.crypto_secretbox_macbytes()
 crypto_secretbox_MESSAGEBYTES_MAX = lib.crypto_secretbox_messagebytes_max()
 
 
-def crypto_secretbox(message, nonce, key):
+def crypto_secretbox(message: bytes, nonce: bytes, key: bytes) -> bytes:
     """
     Encrypts and returns the message ``message`` with the secret ``key`` and
     the nonce ``nonce``.
@@ -52,7 +52,7 @@ def crypto_secretbox(message, nonce, key):
     return ciphertext[crypto_secretbox_BOXZEROBYTES:]
 
 
-def crypto_secretbox_open(ciphertext, nonce, key):
+def crypto_secretbox_open(ciphertext: bytes, nonce: bytes, key: bytes) -> bytes:
     """
     Decrypt and returns the encrypted message ``ciphertext`` with the secret
     ``key`` and the nonce ``nonce``.

--- a/src/nacl/bindings/crypto_secretstream.py
+++ b/src/nacl/bindings/crypto_secretstream.py
@@ -130,7 +130,7 @@ def crypto_secretstream_xchacha20poly1305_push(
     state: crypto_secretstream_xchacha20poly1305_state,
     m: bytes,
     ad: Optional[bytes] = None,
-    tag: int =crypto_secretstream_xchacha20poly1305_TAG_MESSAGE,
+    tag: int = crypto_secretstream_xchacha20poly1305_TAG_MESSAGE,
 ) -> bytes:
     """
     Add an encrypted message to the secret stream.

--- a/src/nacl/bindings/crypto_secretstream.py
+++ b/src/nacl/bindings/crypto_secretstream.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from typing import Optional, Tuple
 
 from nacl import exceptions as exc
 from nacl._sodium import ffi, lib
@@ -49,7 +49,7 @@ crypto_secretstream_xchacha20poly1305_TAG_FINAL = (
 )
 
 
-def crypto_secretstream_xchacha20poly1305_keygen():
+def crypto_secretstream_xchacha20poly1305_keygen() -> bytes:
     """
     Generate a key for use with
     :func:`.crypto_secretstream_xchacha20poly1305_init_push`.
@@ -71,7 +71,7 @@ class crypto_secretstream_xchacha20poly1305_state:
 
     __slots__ = ["statebuf", "rawbuf", "tagbuf"]
 
-    def __init__(self):
+    def __init__(self) -> None:
         """Initialize a clean state object."""
         self.statebuf = ffi.new(
             "unsigned char[]",
@@ -82,7 +82,9 @@ class crypto_secretstream_xchacha20poly1305_state:
         self.tagbuf = None
 
 
-def crypto_secretstream_xchacha20poly1305_init_push(state, key):
+def crypto_secretstream_xchacha20poly1305_init_push(
+        state: crypto_secretstream_xchacha20poly1305_state, key: bytes
+) -> bytes:
     """
     Initialize a crypto_secretstream_xchacha20poly1305 encryption buffer.
 
@@ -125,11 +127,11 @@ def crypto_secretstream_xchacha20poly1305_init_push(state, key):
 
 
 def crypto_secretstream_xchacha20poly1305_push(
-    state,
-    m,
-    ad=None,
-    tag=crypto_secretstream_xchacha20poly1305_TAG_MESSAGE,
-):
+    state: crypto_secretstream_xchacha20poly1305_state,
+    m: bytes,
+    ad: Optional[bytes] = None,
+    tag: int =crypto_secretstream_xchacha20poly1305_TAG_MESSAGE,
+) -> bytes:
     """
     Add an encrypted message to the secret stream.
 
@@ -191,7 +193,11 @@ def crypto_secretstream_xchacha20poly1305_push(
     return ffi.buffer(state.rawbuf, clen)[:]
 
 
-def crypto_secretstream_xchacha20poly1305_init_pull(state, header, key):
+def crypto_secretstream_xchacha20poly1305_init_pull(
+    state: crypto_secretstream_xchacha20poly1305_state,
+    header: bytes,
+    key: bytes,
+) -> None:
     """
     Initialize a crypto_secretstream_xchacha20poly1305 decryption buffer.
 
@@ -240,7 +246,11 @@ def crypto_secretstream_xchacha20poly1305_init_pull(state, header, key):
     ensure(rc == 0, "Unexpected failure", raising=exc.RuntimeError)
 
 
-def crypto_secretstream_xchacha20poly1305_pull(state, c, ad=None):
+def crypto_secretstream_xchacha20poly1305_pull(
+    state: crypto_secretstream_xchacha20poly1305_state,
+    c: bytes,
+    ad: Optional[bytes] = None
+) -> Tuple[bytes, int]:
     """
     Read a decrypted message from the secret stream.
 
@@ -320,7 +330,9 @@ def crypto_secretstream_xchacha20poly1305_pull(state, c, ad=None):
     return (ffi.buffer(state.rawbuf, mlen)[:], int(state.tagbuf[0]))
 
 
-def crypto_secretstream_xchacha20poly1305_rekey(state):
+def crypto_secretstream_xchacha20poly1305_rekey(
+    state: crypto_secretstream_xchacha20poly1305_state,
+) -> None:
     """
     Explicitly change the encryption key in the stream.
 

--- a/src/nacl/bindings/crypto_secretstream.py
+++ b/src/nacl/bindings/crypto_secretstream.py
@@ -83,7 +83,7 @@ class crypto_secretstream_xchacha20poly1305_state:
 
 
 def crypto_secretstream_xchacha20poly1305_init_push(
-        state: crypto_secretstream_xchacha20poly1305_state, key: bytes
+    state: crypto_secretstream_xchacha20poly1305_state, key: bytes
 ) -> bytes:
     """
     Initialize a crypto_secretstream_xchacha20poly1305 encryption buffer.
@@ -249,7 +249,7 @@ def crypto_secretstream_xchacha20poly1305_init_pull(
 def crypto_secretstream_xchacha20poly1305_pull(
     state: crypto_secretstream_xchacha20poly1305_state,
     c: bytes,
-    ad: Optional[bytes] = None
+    ad: Optional[bytes] = None,
 ) -> Tuple[bytes, int]:
     """
     Read a decrypted message from the secret stream.

--- a/src/nacl/bindings/crypto_shorthash.py
+++ b/src/nacl/bindings/crypto_shorthash.py
@@ -33,7 +33,7 @@ if has_crypto_shorthash_siphashx24:
     XKEYBYTES = lib.crypto_shorthash_siphashx24_keybytes()
 
 
-def crypto_shorthash_siphash24(data, key):
+def crypto_shorthash_siphash24(data: bytes, key: bytes) -> bytes:
     """Compute a fast, cryptographic quality, keyed hash of the input data
 
     :param data:
@@ -53,7 +53,7 @@ def crypto_shorthash_siphash24(data, key):
     return ffi.buffer(digest, BYTES)[:]
 
 
-def crypto_shorthash_siphashx24(data, key):
+def crypto_shorthash_siphashx24(data: bytes, key: bytes) -> bytes:
     """Compute a fast, cryptographic quality, keyed hash of the input data
 
     :param data:

--- a/src/nacl/bindings/crypto_sign.py
+++ b/src/nacl/bindings/crypto_sign.py
@@ -209,7 +209,9 @@ class crypto_sign_ed25519ph_state:
         ensure(rc == 0, "Unexpected library error", raising=exc.RuntimeError)
 
 
-def crypto_sign_ed25519ph_update(edph: crypto_sign_ed25519ph_state, pmsg: bytes) -> None:
+def crypto_sign_ed25519ph_update(
+    edph: crypto_sign_ed25519ph_state, pmsg: bytes
+) -> None:
     """
     Update the hash state wrapped in edph
 
@@ -233,7 +235,9 @@ def crypto_sign_ed25519ph_update(edph: crypto_sign_ed25519ph_state, pmsg: bytes)
     ensure(rc == 0, "Unexpected library error", raising=exc.RuntimeError)
 
 
-def crypto_sign_ed25519ph_final_create(edph: crypto_sign_ed25519ph_state, sk: bytes) -> bytes:
+def crypto_sign_ed25519ph_final_create(
+    edph: crypto_sign_ed25519ph_state, sk: bytes
+) -> bytes:
     """
     Create a signature for the data hashed in edph
     using the secret key sk
@@ -272,7 +276,9 @@ def crypto_sign_ed25519ph_final_create(edph: crypto_sign_ed25519ph_state, sk: by
     return ffi.buffer(signature, crypto_sign_BYTES)[:]
 
 
-def crypto_sign_ed25519ph_final_verify(edph: crypto_sign_ed25519ph_state, signature: bytes, pk: bytes) -> bool:
+def crypto_sign_ed25519ph_final_verify(
+    edph: crypto_sign_ed25519ph_state, signature: bytes, pk: bytes
+) -> bool:
     """
     Verify a prehashed signature using the public key pk
 

--- a/src/nacl/bindings/crypto_sign.py
+++ b/src/nacl/bindings/crypto_sign.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from typing import Tuple
 
 from nacl import exceptions as exc
 from nacl._sodium import ffi, lib
@@ -29,7 +29,7 @@ crypto_sign_curve25519_BYTES = lib.crypto_box_secretkeybytes()
 crypto_sign_ed25519ph_STATEBYTES = lib.crypto_sign_ed25519ph_statebytes()
 
 
-def crypto_sign_keypair():
+def crypto_sign_keypair() -> Tuple[bytes, bytes]:
     """
     Returns a randomly generated public key and secret key.
 
@@ -47,7 +47,7 @@ def crypto_sign_keypair():
     )
 
 
-def crypto_sign_seed_keypair(seed):
+def crypto_sign_seed_keypair(seed: bytes) -> Tuple[bytes, bytes]:
     """
     Computes and returns the public key and secret key using the seed ``seed``.
 
@@ -69,7 +69,7 @@ def crypto_sign_seed_keypair(seed):
     )
 
 
-def crypto_sign(message, sk):
+def crypto_sign(message: bytes, sk: bytes) -> bytes:
     """
     Signs the message ``message`` using the secret key ``sk`` and returns the
     signed message.
@@ -87,7 +87,7 @@ def crypto_sign(message, sk):
     return ffi.buffer(signed, signed_len[0])[:]
 
 
-def crypto_sign_open(signed, pk):
+def crypto_sign_open(signed: bytes, pk: bytes) -> bytes:
     """
     Verifies the signature of the signed message ``signed`` using the public
     key ``pk`` and returns the unsigned message.
@@ -108,7 +108,7 @@ def crypto_sign_open(signed, pk):
     return ffi.buffer(message, message_len[0])[:]
 
 
-def crypto_sign_ed25519_pk_to_curve25519(public_key_bytes):
+def crypto_sign_ed25519_pk_to_curve25519(public_key_bytes: bytes) -> bytes:
     """
     Converts a public Ed25519 key (encoded as bytes ``public_key_bytes``) to
     a public Curve25519 key as bytes.
@@ -133,7 +133,7 @@ def crypto_sign_ed25519_pk_to_curve25519(public_key_bytes):
     return ffi.buffer(curve_public_key, curve_public_key_len)[:]
 
 
-def crypto_sign_ed25519_sk_to_curve25519(secret_key_bytes):
+def crypto_sign_ed25519_sk_to_curve25519(secret_key_bytes: bytes) -> bytes:
     """
     Converts a secret Ed25519 key (encoded as bytes ``secret_key_bytes``) to
     a secret Curve25519 key as bytes.
@@ -158,7 +158,7 @@ def crypto_sign_ed25519_sk_to_curve25519(secret_key_bytes):
     return ffi.buffer(curve_secret_key, curve_secret_key_len)[:]
 
 
-def crypto_sign_ed25519_sk_to_pk(secret_key_bytes):
+def crypto_sign_ed25519_sk_to_pk(secret_key_bytes: bytes) -> bytes:
     """
     Extract the public Ed25519 key from a secret Ed25519 key (encoded
     as bytes ``secret_key_bytes``).
@@ -175,7 +175,7 @@ def crypto_sign_ed25519_sk_to_pk(secret_key_bytes):
     return secret_key_bytes[crypto_sign_SEEDBYTES:]
 
 
-def crypto_sign_ed25519_sk_to_seed(secret_key_bytes):
+def crypto_sign_ed25519_sk_to_seed(secret_key_bytes: bytes) -> bytes:
     """
     Extract the seed from a secret Ed25519 key (encoded
     as bytes ``secret_key_bytes``).
@@ -199,7 +199,7 @@ class crypto_sign_ed25519ph_state:
 
     __slots__ = ["state"]
 
-    def __init__(self):
+    def __init__(self) -> None:
         self.state = ffi.new(
             "unsigned char[]", crypto_sign_ed25519ph_STATEBYTES
         )
@@ -209,7 +209,7 @@ class crypto_sign_ed25519ph_state:
         ensure(rc == 0, "Unexpected library error", raising=exc.RuntimeError)
 
 
-def crypto_sign_ed25519ph_update(edph, pmsg):
+def crypto_sign_ed25519ph_update(edph: crypto_sign_ed25519ph_state, pmsg: bytes) -> None:
     """
     Update the hash state wrapped in edph
 
@@ -233,7 +233,7 @@ def crypto_sign_ed25519ph_update(edph, pmsg):
     ensure(rc == 0, "Unexpected library error", raising=exc.RuntimeError)
 
 
-def crypto_sign_ed25519ph_final_create(edph, sk):
+def crypto_sign_ed25519ph_final_create(edph: crypto_sign_ed25519ph_state, sk: bytes) -> bytes:
     """
     Create a signature for the data hashed in edph
     using the secret key sk
@@ -272,7 +272,7 @@ def crypto_sign_ed25519ph_final_create(edph, sk):
     return ffi.buffer(signature, crypto_sign_BYTES)[:]
 
 
-def crypto_sign_ed25519ph_final_verify(edph, signature, pk):
+def crypto_sign_ed25519ph_final_verify(edph: crypto_sign_ed25519ph_state, signature: bytes, pk: bytes) -> bool:
     """
     Verify a prehashed signature using the public key pk
 

--- a/src/nacl/bindings/randombytes.py
+++ b/src/nacl/bindings/randombytes.py
@@ -19,7 +19,7 @@ from nacl._sodium import ffi, lib
 randombytes_SEEDBYTES = lib.randombytes_seedbytes()
 
 
-def randombytes(size):
+def randombytes(size: int) -> bytes:
     """
     Returns ``size`` number of random bytes from a cryptographically secure
     random source.
@@ -32,7 +32,7 @@ def randombytes(size):
     return ffi.buffer(buf, size)[:]
 
 
-def randombytes_buf_deterministic(size, seed):
+def randombytes_buf_deterministic(size: int, seed: bytes) -> bytes:
     """
     Returns ``size`` number of deterministically generated pseudorandom bytes
     from a seed

--- a/src/nacl/bindings/sodium_core.py
+++ b/src/nacl/bindings/sodium_core.py
@@ -17,7 +17,7 @@ from nacl._sodium import ffi, lib
 from nacl.exceptions import ensure
 
 
-def _sodium_init():
+def _sodium_init() -> None:
     ensure(
         lib.sodium_init() != -1,
         "Could not initialize sodium",
@@ -25,7 +25,7 @@ def _sodium_init():
     )
 
 
-def sodium_init():
+def sodium_init() -> None:
     """
     Initializes sodium, picking the best implementations available for this
     machine.

--- a/src/nacl/bindings/utils.py
+++ b/src/nacl/bindings/utils.py
@@ -17,7 +17,7 @@ from nacl._sodium import ffi, lib
 from nacl.exceptions import ensure
 
 
-def sodium_memcmp(inp1, inp2):
+def sodium_memcmp(inp1: bytes, inp2: bytes) -> bool:
     """
     Compare contents of two memory regions in constant time
     """
@@ -38,7 +38,7 @@ def sodium_memcmp(inp1, inp2):
     return eqL and eqC
 
 
-def sodium_pad(s, blocksize):
+def sodium_pad(s: bytes, blocksize: int) -> bytes:
     """
     Pad the input bytearray ``s`` to a multiple of ``blocksize``
     using the ISO/IEC 7816-4 algorithm
@@ -64,7 +64,7 @@ def sodium_pad(s, blocksize):
     return ffi.buffer(buf, p_len[0])[:]
 
 
-def sodium_unpad(s, blocksize):
+def sodium_unpad(s: bytes, blocksize: int) -> bytes:
     """
     Remove ISO/IEC 7816-4 padding from the input byte array ``s``
 
@@ -85,7 +85,7 @@ def sodium_unpad(s, blocksize):
     return s[: u_len[0]]
 
 
-def sodium_increment(inp):
+def sodium_increment(inp: bytes) -> bytes:
     """
     Increment the value of a byte-sequence interpreted
     as the little-endian representation of a unsigned big integer.
@@ -110,7 +110,7 @@ def sodium_increment(inp):
     return ffi.buffer(buf, ln)[:]
 
 
-def sodium_add(a, b):
+def sodium_add(a: bytes, b: bytes) -> bytes:
     """
     Given a couple of *same-sized* byte sequences, interpreted as the
     little-endian representation of two unsigned integers, compute

--- a/src/nacl/encoding.py
+++ b/src/nacl/encoding.py
@@ -15,68 +15,86 @@
 
 import base64
 import binascii
+from typing import Type
+
+from typing_extensions import Protocol
+
+
+class _Encoder(Protocol):
+    @staticmethod
+    def encode(data: bytes) -> bytes: ...
+
+    @staticmethod
+    def decode(data: bytes) -> bytes: ...
+
+
+Encoder = Type[_Encoder]
+
+
+class SupportsBytes(Protocol):
+    def __bytes__(self) -> bytes: ...
 
 
 class RawEncoder:
     @staticmethod
-    def encode(data):
+    def encode(data: bytes) -> bytes:
         return data
 
     @staticmethod
-    def decode(data):
+    def decode(data: bytes) -> bytes:
         return data
 
 
 class HexEncoder:
     @staticmethod
-    def encode(data):
+    def encode(data: bytes) -> bytes:
         return binascii.hexlify(data)
 
     @staticmethod
-    def decode(data):
+    def decode(data: bytes) -> bytes:
         return binascii.unhexlify(data)
 
 
 class Base16Encoder:
     @staticmethod
-    def encode(data):
+    def encode(data: bytes) -> bytes:
         return base64.b16encode(data)
 
     @staticmethod
-    def decode(data):
+    def decode(data: bytes) -> bytes:
         return base64.b16decode(data)
 
 
 class Base32Encoder:
     @staticmethod
-    def encode(data):
+    def encode(data: bytes) -> bytes:
         return base64.b32encode(data)
 
     @staticmethod
-    def decode(data):
+    def decode(data: bytes) -> bytes:
         return base64.b32decode(data)
 
 
 class Base64Encoder:
     @staticmethod
-    def encode(data):
+    def encode(data: bytes) -> bytes:
         return base64.b64encode(data)
 
     @staticmethod
-    def decode(data):
+    def decode(data: bytes) -> bytes:
         return base64.b64decode(data)
 
 
 class URLSafeBase64Encoder:
     @staticmethod
-    def encode(data):
+    def encode(data: bytes) -> bytes:
         return base64.urlsafe_b64encode(data)
 
     @staticmethod
-    def decode(data):
+    def decode(data: bytes) -> bytes:
         return base64.urlsafe_b64decode(data)
 
 
 class Encodable:
-    def encode(self, encoder=RawEncoder):
+    def encode(self: SupportsBytes, encoder: Encoder = RawEncoder) -> bytes:
         return encoder.encode(bytes(self))

--- a/src/nacl/encoding.py
+++ b/src/nacl/encoding.py
@@ -22,17 +22,20 @@ from typing_extensions import Protocol
 
 class _Encoder(Protocol):
     @staticmethod
-    def encode(data: bytes) -> bytes: ...
+    def encode(data: bytes) -> bytes:
+        ...
 
     @staticmethod
-    def decode(data: bytes) -> bytes: ...
+    def decode(data: bytes) -> bytes:
+        ...
 
 
 Encoder = Type[_Encoder]
 
 
 class SupportsBytes(Protocol):
-    def __bytes__(self) -> bytes: ...
+    def __bytes__(self) -> bytes:
+        ...
 
 
 class RawEncoder:

--- a/src/nacl/exceptions.py
+++ b/src/nacl/exceptions.py
@@ -13,7 +13,11 @@
 # limitations under the License.
 
 
-class CryptoError(Exception):
+import builtins
+from typing import Any, Type
+
+
+class CryptoError(builtins.Exception):
     """
     Base exception for all nacl related errors
     """
@@ -25,19 +29,19 @@ class BadSignatureError(CryptoError):
     """
 
 
-class RuntimeError(RuntimeError, CryptoError):
+class RuntimeError(builtins.RuntimeError, CryptoError):
     pass
 
 
-class AssertionError(AssertionError, CryptoError):
+class AssertionError(builtins.AssertionError, CryptoError):
     pass
 
 
-class TypeError(TypeError, CryptoError):
+class TypeError(builtins.TypeError, CryptoError):
     pass
 
 
-class ValueError(ValueError, CryptoError):
+class ValueError(builtins.ValueError, CryptoError):
     pass
 
 
@@ -59,7 +63,7 @@ class UnavailableError(RuntimeError):
     pass
 
 
-def ensure(cond, *args, **kwds):
+def ensure(cond: bool, *args: Any, **kwds: Type[Exception]) -> None:
     """
     Return if a condition is true, otherwise raise a caller-configurable
     :py:class:`Exception`

--- a/src/nacl/hash.py
+++ b/src/nacl/hash.py
@@ -60,8 +60,7 @@ _sip_hashx = nacl.bindings.crypto_shorthash_siphashx24
 
 
 def sha256(
-    message: bytes,
-    encoder: nacl.encoding.Encoder = nacl.encoding.HexEncoder
+    message: bytes, encoder: nacl.encoding.Encoder = nacl.encoding.HexEncoder
 ) -> bytes:
     """
     Hashes ``message`` with SHA256.
@@ -76,8 +75,7 @@ def sha256(
 
 
 def sha512(
-    message: bytes,
-    encoder: nacl.encoding.Encoder = nacl.encoding.HexEncoder
+    message: bytes, encoder: nacl.encoding.Encoder = nacl.encoding.HexEncoder
 ) -> bytes:
     """
     Hashes ``message`` with SHA512.

--- a/src/nacl/hash.py
+++ b/src/nacl/hash.py
@@ -59,7 +59,10 @@ _sip_hash = nacl.bindings.crypto_shorthash_siphash24
 _sip_hashx = nacl.bindings.crypto_shorthash_siphashx24
 
 
-def sha256(message, encoder=nacl.encoding.HexEncoder):
+def sha256(
+    message: bytes,
+    encoder: nacl.encoding.Encoder = nacl.encoding.HexEncoder
+) -> bytes:
     """
     Hashes ``message`` with SHA256.
 
@@ -72,7 +75,10 @@ def sha256(message, encoder=nacl.encoding.HexEncoder):
     return encoder.encode(nacl.bindings.crypto_hash_sha256(message))
 
 
-def sha512(message, encoder=nacl.encoding.HexEncoder):
+def sha512(
+    message: bytes,
+    encoder: nacl.encoding.Encoder = nacl.encoding.HexEncoder
+) -> bytes:
     """
     Hashes ``message`` with SHA512.
 
@@ -86,13 +92,13 @@ def sha512(message, encoder=nacl.encoding.HexEncoder):
 
 
 def blake2b(
-    data,
-    digest_size=BLAKE2B_BYTES,
-    key=b"",
-    salt=b"",
-    person=b"",
-    encoder=nacl.encoding.HexEncoder,
-):
+    data: bytes,
+    digest_size: int = BLAKE2B_BYTES,
+    key: bytes = b"",
+    salt: bytes = b"",
+    person: bytes = b"",
+    encoder: nacl.encoding.Encoder = nacl.encoding.HexEncoder,
+) -> bytes:
     """
     Hashes ``data`` with blake2b.
 
@@ -129,7 +135,11 @@ def blake2b(
 generichash = blake2b
 
 
-def siphash24(message, key=b"", encoder=nacl.encoding.HexEncoder):
+def siphash24(
+    message: bytes,
+    key: bytes = b"",
+    encoder: nacl.encoding.Encoder = nacl.encoding.HexEncoder,
+) -> bytes:
     """
     Computes a keyed MAC of ``message`` using the short-input-optimized
     siphash-2-4 construction.
@@ -149,7 +159,11 @@ def siphash24(message, key=b"", encoder=nacl.encoding.HexEncoder):
 shorthash = siphash24
 
 
-def siphashx24(message, key=b"", encoder=nacl.encoding.HexEncoder):
+def siphashx24(
+    message: bytes,
+    key: bytes = b"",
+    encoder: nacl.encoding.Encoder = nacl.encoding.HexEncoder,
+) -> bytes:
     """
     Computes a keyed MAC of ``message`` using the 128 bit variant of the
     siphash-2-4 construction.

--- a/src/nacl/hashlib.py
+++ b/src/nacl/hashlib.py
@@ -14,6 +14,7 @@
 
 
 import binascii
+from typing import NoReturn
 
 import nacl.bindings
 from nacl.utils import bytes_as_string
@@ -45,7 +46,12 @@ class blake2b:
     SALT_SIZE = SALTBYTES
 
     def __init__(
-        self, data=b"", digest_size=BYTES, key=b"", salt=b"", person=b""
+        self,
+        data: bytes = b"",
+        digest_size: int = BYTES,
+        key: bytes = b"",
+        salt: bytes = b"",
+        person: bytes = b""
     ):
         """
         :py:class:`.blake2b` algorithm initializer
@@ -77,34 +83,34 @@ class blake2b:
             self.update(data)
 
     @property
-    def digest_size(self):
+    def digest_size(self) -> int:
         return self._digest_size
 
     @property
-    def block_size(self):
+    def block_size(self) -> int:
         return 128
 
     @property
-    def name(self):
+    def name(self) -> str:
         return "blake2b"
 
-    def update(self, data):
+    def update(self, data: bytes) -> None:
         _b2b_update(self._state, data)
 
-    def digest(self):
+    def digest(self) -> bytes:
         _st = self._state.copy()
         return _b2b_final(_st)
 
-    def hexdigest(self):
+    def hexdigest(self) -> str:
         return bytes_as_string(binascii.hexlify(self.digest()))
 
-    def copy(self):
+    def copy(self) -> "blake2b":
         _cp = type(self)(digest_size=self.digest_size)
         _st = self._state.copy()
         _cp._state = _st
         return _cp
 
-    def __reduce__(self):
+    def __reduce__(self) -> NoReturn:
         """
         Raise the same exception as hashlib's blake implementation
         on copy.copy()
@@ -114,7 +120,15 @@ class blake2b:
         )
 
 
-def scrypt(password, salt="", n=2 ** 20, r=8, p=1, maxmem=2 ** 25, dklen=64):
+def scrypt(
+    password: bytes,
+    salt: bytes = b"",
+    n: int = 2 ** 20,
+    r: int = 8,
+    p: int = 1,
+    maxmem: int = 2 ** 25,
+    dklen: int = 64,
+) -> bytes:
     """
     Derive a cryptographic key using the scrypt KDF.
 

--- a/src/nacl/hashlib.py
+++ b/src/nacl/hashlib.py
@@ -51,7 +51,7 @@ class blake2b:
         digest_size: int = BYTES,
         key: bytes = b"",
         salt: bytes = b"",
-        person: bytes = b""
+        person: bytes = b"",
     ):
         """
         :py:class:`.blake2b` algorithm initializer

--- a/src/nacl/public.py
+++ b/src/nacl/public.py
@@ -86,7 +86,7 @@ class PrivateKey(encoding.Encodable, StringFixer):
     def __init__(
         self,
         private_key: bytes,
-        encoder: encoding.Encoder = encoding.RawEncoder
+        encoder: encoding.Encoder = encoding.RawEncoder,
     ):
         # Decode the secret_key
         private_key = encoder.decode(private_key)
@@ -212,9 +212,7 @@ class Box(encoding.Encodable, StringFixer):
 
     @classmethod
     def decode(
-        cls,
-        encoded: bytes,
-        encoder: encoding.Encoder = encoding.RawEncoder
+        cls, encoded: bytes, encoder: encoding.Encoder = encoding.RawEncoder
     ) -> "Box":
         # Create an empty box
         box = cls(None, None)

--- a/src/nacl/pwhash/__init__.py
+++ b/src/nacl/pwhash/__init__.py
@@ -54,7 +54,7 @@ scryptsalsa208sha256_str = scrypt.str
 verify_scryptsalsa208sha256 = scrypt.verify
 
 
-def verify(password_hash, password):
+def verify(password_hash: bytes, password: bytes) -> bool:
     """
     Takes a modular crypt encoded stored password hash derived using one
     of the algorithms supported by `libsodium` and checks if the user provided

--- a/src/nacl/pwhash/_argon2.py
+++ b/src/nacl/pwhash/_argon2.py
@@ -32,7 +32,7 @@ ALG_ARGON2ID13 = nacl.bindings.crypto_pwhash_ALG_ARGON2ID13
 ALG_ARGON2_DEFAULT = nacl.bindings.crypto_pwhash_ALG_DEFAULT
 
 
-def verify(password_hash, password):
+def verify(password_hash: bytes, password: bytes) -> bool:
     """
     Takes a modular crypt encoded argon2i or argon2id stored password hash
     and checks if the user provided password will hash to the same string

--- a/src/nacl/pwhash/argon2i.py
+++ b/src/nacl/pwhash/argon2i.py
@@ -47,13 +47,13 @@ MEMLIMIT_MODERATE = nacl.bindings.crypto_pwhash_argon2i_MEMLIMIT_MODERATE
 
 
 def kdf(
-    size,
-    password,
-    salt,
-    opslimit=OPSLIMIT_SENSITIVE,
-    memlimit=MEMLIMIT_SENSITIVE,
-    encoder=nacl.encoding.RawEncoder,
-):
+    size: int,
+    password: bytes,
+    salt: bytes,
+    opslimit: int = OPSLIMIT_SENSITIVE,
+    memlimit: int = MEMLIMIT_SENSITIVE,
+    encoder: nacl.encoding.Encoder = nacl.encoding.RawEncoder,
+) -> bytes:
     """
     Derive a ``size`` bytes long key from a caller-supplied
     ``password`` and ``salt`` pair using the argon2i
@@ -107,8 +107,10 @@ def kdf(
 
 
 def str(
-    password, opslimit=OPSLIMIT_INTERACTIVE, memlimit=MEMLIMIT_INTERACTIVE
-):
+    password: bytes,
+    opslimit: int = OPSLIMIT_INTERACTIVE,
+    memlimit: int = MEMLIMIT_INTERACTIVE,
+) -> bytes:
     """
     Hashes a password with a random salt, using the memory-hard
     argon2i construct and returning an ascii string that has all

--- a/src/nacl/pwhash/argon2id.py
+++ b/src/nacl/pwhash/argon2id.py
@@ -51,13 +51,13 @@ MEMLIMIT_MODERATE = nacl.bindings.crypto_pwhash_argon2id_MEMLIMIT_MODERATE
 
 
 def kdf(
-    size,
-    password,
-    salt,
-    opslimit=OPSLIMIT_SENSITIVE,
-    memlimit=MEMLIMIT_SENSITIVE,
-    encoder=nacl.encoding.RawEncoder,
-):
+    size: int,
+    password: bytes,
+    salt: bytes,
+    opslimit: int = OPSLIMIT_SENSITIVE,
+    memlimit: int = MEMLIMIT_SENSITIVE,
+    encoder: nacl.encoding.Encoder = nacl.encoding.RawEncoder,
+) -> bytes:
     """
     Derive a ``size`` bytes long key from a caller-supplied
     ``password`` and ``salt`` pair using the argon2i
@@ -111,8 +111,10 @@ def kdf(
 
 
 def str(
-    password, opslimit=OPSLIMIT_INTERACTIVE, memlimit=MEMLIMIT_INTERACTIVE
-):
+    password: bytes,
+    opslimit: int = OPSLIMIT_INTERACTIVE,
+    memlimit: int =MEMLIMIT_INTERACTIVE,
+) -> bytes:
     """
     Hashes a password with a random salt, using the memory-hard
     argon2id construct and returning an ascii string that has all

--- a/src/nacl/pwhash/argon2id.py
+++ b/src/nacl/pwhash/argon2id.py
@@ -113,7 +113,7 @@ def kdf(
 def str(
     password: bytes,
     opslimit: int = OPSLIMIT_INTERACTIVE,
-    memlimit: int =MEMLIMIT_INTERACTIVE,
+    memlimit: int = MEMLIMIT_INTERACTIVE,
 ) -> bytes:
     """
     Hashes a password with a random salt, using the memory-hard

--- a/src/nacl/pwhash/scrypt.py
+++ b/src/nacl/pwhash/scrypt.py
@@ -56,13 +56,13 @@ MEMLIMIT_MODERATE = 8 * MEMLIMIT_INTERACTIVE
 
 
 def kdf(
-    size,
-    password,
-    salt,
-    opslimit=OPSLIMIT_SENSITIVE,
-    memlimit=MEMLIMIT_SENSITIVE,
-    encoder=nacl.encoding.RawEncoder,
-):
+    size: int,
+    password: bytes,
+    salt: bytes,
+    opslimit: int = OPSLIMIT_SENSITIVE,
+    memlimit: int = MEMLIMIT_SENSITIVE,
+    encoder: nacl.encoding.Encoder = nacl.encoding.RawEncoder,
+) -> bytes:
     """
     Derive a ``size`` bytes long key from a caller-supplied
     ``password`` and ``salt`` pair using the scryptsalsa208sha256
@@ -138,8 +138,10 @@ def kdf(
 
 
 def str(
-    password, opslimit=OPSLIMIT_INTERACTIVE, memlimit=MEMLIMIT_INTERACTIVE
-):
+    password: bytes,
+    opslimit: int = OPSLIMIT_INTERACTIVE,
+    memlimit: int = MEMLIMIT_INTERACTIVE,
+) -> bytes:
     """
     Hashes a password with a random salt, using the memory-hard
     scryptsalsa208sha256 construct and returning an ascii string
@@ -168,7 +170,7 @@ def str(
     )
 
 
-def verify(password_hash, password):
+def verify(password_hash: bytes, password: bytes) -> bool:
     """
     Takes the output of scryptsalsa208sha256 and compares it against
     a user provided password to see if they are the same

--- a/src/nacl/secret.py
+++ b/src/nacl/secret.py
@@ -55,9 +55,7 @@ class SecretBox(encoding.Encodable, StringFixer):
     MESSAGEBYTES_MAX = nacl.bindings.crypto_secretbox_MESSAGEBYTES_MAX
 
     def __init__(
-        self,
-        key: bytes,
-        encoder: encoding.Encoder = encoding.RawEncoder
+        self, key: bytes, encoder: encoding.Encoder = encoding.RawEncoder
     ):
         key = encoder.decode(key)
         if not isinstance(key, bytes):

--- a/src/nacl/secret.py
+++ b/src/nacl/secret.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from typing import Optional
 
 import nacl.bindings
 from nacl import encoding
@@ -54,7 +54,11 @@ class SecretBox(encoding.Encodable, StringFixer):
     MACBYTES = nacl.bindings.crypto_secretbox_MACBYTES
     MESSAGEBYTES_MAX = nacl.bindings.crypto_secretbox_MESSAGEBYTES_MAX
 
-    def __init__(self, key, encoder=encoding.RawEncoder):
+    def __init__(
+        self,
+        key: bytes,
+        encoder: encoding.Encoder = encoding.RawEncoder
+    ):
         key = encoder.decode(key)
         if not isinstance(key, bytes):
             raise exc.TypeError("SecretBox must be created from 32 bytes")
@@ -66,10 +70,15 @@ class SecretBox(encoding.Encodable, StringFixer):
 
         self._key = key
 
-    def __bytes__(self):
+    def __bytes__(self) -> bytes:
         return self._key
 
-    def encrypt(self, plaintext, nonce=None, encoder=encoding.RawEncoder):
+    def encrypt(
+        self,
+        plaintext: bytes,
+        nonce: Optional[bytes] = None,
+        encoder: encoding.Encoder = encoding.RawEncoder,
+    ) -> EncryptedMessage:
         """
         Encrypts the plaintext message using the given `nonce` (or generates
         one randomly if omitted) and returns the ciphertext encoded with the
@@ -107,7 +116,12 @@ class SecretBox(encoding.Encodable, StringFixer):
             encoder.encode(nonce + ciphertext),
         )
 
-    def decrypt(self, ciphertext, nonce=None, encoder=encoding.RawEncoder):
+    def decrypt(
+        self,
+        ciphertext: bytes,
+        nonce: Optional[bytes] = None,
+        encoder: encoding.Encoder = encoding.RawEncoder,
+    ) -> bytes:
         """
         Decrypts the ciphertext using the `nonce` (explicitly, when passed as a
         parameter or implicitly, when omitted, as part of the ciphertext) and
@@ -183,7 +197,11 @@ class Aead(encoding.Encodable, StringFixer):
         nacl.bindings.crypto_aead_xchacha20poly1305_ietf_MESSAGEBYTES_MAX
     )
 
-    def __init__(self, key, encoder=encoding.RawEncoder):
+    def __init__(
+        self,
+        key: bytes,
+        encoder: encoding.Encoder = encoding.RawEncoder,
+    ):
         key = encoder.decode(key)
         if not isinstance(key, bytes):
             raise exc.TypeError("AEAD must be created from 32 bytes")
@@ -195,12 +213,16 @@ class Aead(encoding.Encodable, StringFixer):
 
         self._key = key
 
-    def __bytes__(self):
+    def __bytes__(self) -> bytes:
         return self._key
 
     def encrypt(
-        self, plaintext, aad=b"", nonce=None, encoder=encoding.RawEncoder
-    ):
+        self,
+        plaintext: bytes,
+        aad: bytes = b"",
+        nonce: Optional[bytes] = None,
+        encoder: encoding.Encoder = encoding.RawEncoder,
+    ) -> EncryptedMessage:
         """
         Encrypts the plaintext message using the given `nonce` (or generates
         one randomly if omitted) and returns the ciphertext encoded with the
@@ -246,8 +268,12 @@ class Aead(encoding.Encodable, StringFixer):
         )
 
     def decrypt(
-        self, ciphertext, aad=b"", nonce=None, encoder=encoding.RawEncoder
-    ):
+        self,
+        ciphertext: bytes,
+        aad: bytes = b"",
+        nonce: Optional[bytes] = None,
+        encoder: encoding.Encoder = encoding.RawEncoder,
+    ) -> bytes:
         """
         Decrypts the ciphertext using the `nonce` (explicitly, when passed as a
         parameter or implicitly, when omitted, as part of the ciphertext) and

--- a/src/nacl/signing.py
+++ b/src/nacl/signing.py
@@ -66,9 +66,7 @@ class VerifyKey(encoding.Encodable, StringFixer):
     """
 
     def __init__(
-        self,
-        key: bytes,
-        encoder: encoding.Encoder = encoding.RawEncoder
+        self, key: bytes, encoder: encoding.Encoder = encoding.RawEncoder
     ):
         # Decode the key
         key = encoder.decode(key)

--- a/src/nacl/signing.py
+++ b/src/nacl/signing.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
+from typing import Optional
 
 import nacl.bindings
 from nacl import encoding
@@ -29,22 +29,27 @@ class SignedMessage(bytes):
     :class:`SigningKey`.
     """
 
+    _signature: bytes
+    _message: bytes
+
     @classmethod
-    def _from_parts(cls, signature, message, combined):
+    def _from_parts(
+        cls, signature: bytes, message: bytes, combined: bytes
+    ) -> "SignedMessage":
         obj = cls(combined)
         obj._signature = signature
         obj._message = message
         return obj
 
     @property
-    def signature(self):
+    def signature(self) -> bytes:
         """
         The signature contained within the :class:`SignedMessage`.
         """
         return self._signature
 
     @property
-    def message(self):
+    def message(self) -> bytes:
         """
         The message contained within the :class:`SignedMessage`.
         """
@@ -60,7 +65,11 @@ class VerifyKey(encoding.Encodable, StringFixer):
     :param encoder: A class that is able to decode the `key`
     """
 
-    def __init__(self, key, encoder=encoding.RawEncoder):
+    def __init__(
+        self,
+        key: bytes,
+        encoder: encoding.Encoder = encoding.RawEncoder
+    ):
         # Decode the key
         key = encoder.decode(key)
         if not isinstance(key, bytes):
@@ -74,21 +83,26 @@ class VerifyKey(encoding.Encodable, StringFixer):
 
         self._key = key
 
-    def __bytes__(self):
+    def __bytes__(self) -> bytes:
         return self._key
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(bytes(self))
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, self.__class__):
             return False
         return nacl.bindings.sodium_memcmp(bytes(self), bytes(other))
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         return not (self == other)
 
-    def verify(self, smessage, signature=None, encoder=encoding.RawEncoder):
+    def verify(
+        self,
+        smessage: bytes,
+        signature: Optional[bytes] = None,
+        encoder: encoding.Encoder = encoding.RawEncoder,
+    ) -> bytes:
         """
         Verifies the signature of a signed message, returning the message
         if it has not been tampered with else raising
@@ -124,7 +138,7 @@ class VerifyKey(encoding.Encodable, StringFixer):
 
         return nacl.bindings.crypto_sign_open(smessage, self._key)
 
-    def to_curve25519_public_key(self):
+    def to_curve25519_public_key(self) -> _Curve25519_PublicKey:
         """
         Converts a :class:`~nacl.signing.VerifyKey` to a
         :class:`~nacl.public.PublicKey`
@@ -154,7 +168,11 @@ class SigningKey(encoding.Encodable, StringFixer):
         (i.e. public) key that corresponds with this signing key.
     """
 
-    def __init__(self, seed, encoder=encoding.RawEncoder):
+    def __init__(
+        self,
+        seed: bytes,
+        encoder: encoding.Encoder = encoding.RawEncoder,
+    ):
         # Decode the seed
         seed = encoder.decode(seed)
         if not isinstance(seed, bytes):
@@ -175,22 +193,22 @@ class SigningKey(encoding.Encodable, StringFixer):
         self._signing_key = secret_key
         self.verify_key = VerifyKey(public_key)
 
-    def __bytes__(self):
+    def __bytes__(self) -> bytes:
         return self._seed
 
-    def __hash__(self):
+    def __hash__(self) -> int:
         return hash(bytes(self))
 
-    def __eq__(self, other):
+    def __eq__(self, other: object) -> bool:
         if not isinstance(other, self.__class__):
             return False
         return nacl.bindings.sodium_memcmp(bytes(self), bytes(other))
 
-    def __ne__(self, other):
+    def __ne__(self, other: object) -> bool:
         return not (self == other)
 
     @classmethod
-    def generate(cls):
+    def generate(cls) -> "SigningKey":
         """
         Generates a random :class:`~nacl.signing.SigningKey` object.
 
@@ -201,7 +219,11 @@ class SigningKey(encoding.Encodable, StringFixer):
             encoder=encoding.RawEncoder,
         )
 
-    def sign(self, message, encoder=encoding.RawEncoder):
+    def sign(
+        self,
+        message: bytes,
+        encoder: encoding.Encoder = encoding.RawEncoder,
+    ) -> SignedMessage:
         """
         Sign a message using this key.
 
@@ -218,7 +240,7 @@ class SigningKey(encoding.Encodable, StringFixer):
 
         return SignedMessage._from_parts(signature, message, signed)
 
-    def to_curve25519_private_key(self):
+    def to_curve25519_private_key(self) -> _Curve25519_PrivateKey:
         """
         Converts a :class:`~nacl.signing.SigningKey` to a
         :class:`~nacl.public.PrivateKey`

--- a/src/nacl/utils.py
+++ b/src/nacl/utils.py
@@ -25,22 +25,27 @@ class EncryptedMessage(bytes):
     :class:`SecretBox`.
     """
 
+    _nonce: bytes
+    _ciphertext: bytes
+
     @classmethod
-    def _from_parts(cls, nonce, ciphertext, combined):
+    def _from_parts(
+        cls, nonce: bytes, ciphertext: bytes, combined: bytes
+    ) -> "EncryptedMessage":
         obj = cls(combined)
         obj._nonce = nonce
         obj._ciphertext = ciphertext
         return obj
 
     @property
-    def nonce(self):
+    def nonce(self) -> bytes:
         """
         The nonce used during the encryption of the :class:`EncryptedMessage`.
         """
         return self._nonce
 
     @property
-    def ciphertext(self):
+    def ciphertext(self) -> bytes:
         """
         The ciphertext contained within the :class:`EncryptedMessage`.
         """
@@ -48,19 +53,21 @@ class EncryptedMessage(bytes):
 
 
 class StringFixer:
-    def __str__(self):
+    def __str__(self: encoding.SupportsBytes) -> str:
         return str(self.__bytes__())
 
 
-def bytes_as_string(bytes_in):
+def bytes_as_string(bytes_in: bytes) -> str:
     return bytes_in.decode("ascii")
 
 
-def random(size=32):
+def random(size: int = 32) -> bytes:
     return os.urandom(size)
 
 
-def randombytes_deterministic(size, seed, encoder=encoding.RawEncoder):
+def randombytes_deterministic(
+    size: int, seed: bytes, encoder: encoding.Encoder = encoding.RawEncoder
+) -> bytes:
     """
     Returns ``size`` number of deterministically generated pseudorandom bytes
     from a seed


### PR DESCRIPTION
Fixes #660.

I went on a bit of an annotating spree and I think I managed to get all of the functions in `nacl` annotated. For the most part it was a case of propagating the existing type hints in the docstrings and reformatting them.

It's worth highlighting that I'm not a cryptography expert! All eyes on the changes are appreciated.

Methodology:
- configure mypy to ignore `nacl._sodium` since that's the C extension(?)
- run `mypy --disallow-untyped-defs src/nacl` to spot untyped functions
- annotate them
- rerun mypy and continue.

One thing I'm not sure about: to annotate the `encoder` arguments I made use of a `typing.Protocol`. That was added in Python 3.8; I pulled in `typing_extensions` so that it's available in Python 3.6 and 3.7. But having done that, I wasn't sure if adding a dependency was a good idea. Perhaps a try-except along these lines might be better?

```
try:
    from typing import Protocol
except ImportError:
    class Protocol: pass
```

----

I also ran `mypy --strict` out of curiosity.

- It was mostly unhappy that I was returning expressions of the form `ffi.buffer(foo, bar)[:]`. From mypy's perspective these have type `Any`, but I was returning them from functions which had been marked as returning `bool`.
- It was also unhappy about parts of `Box.decode`, but I don't think there was anything obviously wrong there---there's just some trickery in passing `None` to `Box.__init__`.
- Lastly mypy spotted that `SealedBox.decrypt` could have `self._private_key = None`, which would contradict the type of `crypto_box_seal_open`'s `sk` argument. This happens if the `SealedBox` is created with a `PublicKey`, not a `PrivateKey`. That probably makes sense: shouldn't be able to decrypt without a `PrivateKey`!