### PR TITLE
Type annotations for `nacl.utils`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ ignore_missing_imports = true
 module = [
     "nacl.encoding",
     "nacl.exceptions",
+    "nacl.utils",
 ]
 disallow_any_unimported = true
 disallow_any_expr = true

--- a/src/nacl/bindings/randombytes.py
+++ b/src/nacl/bindings/randombytes.py
@@ -32,7 +32,7 @@ def randombytes(size):
     return ffi.buffer(buf, size)[:]
 
 
-def randombytes_buf_deterministic(size, seed):
+def randombytes_buf_deterministic(size: int, seed: bytes) -> bytes:
     """
     Returns ``size`` number of deterministically generated pseudorandom bytes
     from a seed

--- a/src/nacl/utils.py
+++ b/src/nacl/utils.py
@@ -19,7 +19,7 @@ from typing import SupportsBytes, Type, TypeVar
 import nacl.bindings
 from nacl import encoding
 
-C = TypeVar("C", bound="EncryptedMessage")
+_EncryptedMessage = TypeVar("_EncryptedMessage", bound="EncryptedMessage")
 
 
 class EncryptedMessage(bytes):
@@ -33,8 +33,8 @@ class EncryptedMessage(bytes):
 
     @classmethod
     def _from_parts(
-        cls: Type[C], nonce: bytes, ciphertext: bytes, combined: bytes
-    ) -> C:
+        cls: Type[_EncryptedMessage], nonce: bytes, ciphertext: bytes, combined: bytes
+    ) -> _EncryptedMessage:
         obj = cls(combined)
         obj._nonce = nonce
         obj._ciphertext = ciphertext

--- a/src/nacl/utils.py
+++ b/src/nacl/utils.py
@@ -14,10 +14,12 @@
 
 
 import os
-from typing import SupportsBytes
+from typing import SupportsBytes, Type, TypeVar
 
 import nacl.bindings
 from nacl import encoding
+
+C = TypeVar("C", bound="EncryptedMessage")
 
 
 class EncryptedMessage(bytes):
@@ -26,25 +28,27 @@ class EncryptedMessage(bytes):
     :class:`SecretBox`.
     """
 
-    _nonce = object
-    _ciphertext = object
+    _nonce: bytes
+    _ciphertext: bytes
 
     @classmethod
-    def _from_parts(cls, nonce, ciphertext, combined):
+    def _from_parts(
+        cls: Type[C], nonce: bytes, ciphertext: bytes, combined: bytes
+    ) -> C:
         obj = cls(combined)
         obj._nonce = nonce
         obj._ciphertext = ciphertext
         return obj
 
     @property
-    def nonce(self):
+    def nonce(self) -> bytes:
         """
         The nonce used during the encryption of the :class:`EncryptedMessage`.
         """
         return self._nonce
 
     @property
-    def ciphertext(self):
+    def ciphertext(self) -> bytes:
         """
         The ciphertext contained within the :class:`EncryptedMessage`.
         """
@@ -52,19 +56,21 @@ class EncryptedMessage(bytes):
 
 
 class StringFixer:
-    def __str__(self: SupportsBytes):
+    def __str__(self: SupportsBytes) -> str:
         return str(self.__bytes__())
 
 
-def bytes_as_string(bytes_in):
+def bytes_as_string(bytes_in: bytes) -> str:
     return bytes_in.decode("ascii")
 
 
-def random(size=32):
+def random(size: int = 32) -> bytes:
     return os.urandom(size)
 
 
-def randombytes_deterministic(size, seed, encoder=encoding.RawEncoder):
+def randombytes_deterministic(
+    size: int, seed: bytes, encoder: encoding.Encoder = encoding.RawEncoder
+) -> bytes:
     """
     Returns ``size`` number of deterministically generated pseudorandom bytes
     from a seed

--- a/src/nacl/utils.py
+++ b/src/nacl/utils.py
@@ -33,7 +33,10 @@ class EncryptedMessage(bytes):
 
     @classmethod
     def _from_parts(
-        cls: Type[_EncryptedMessage], nonce: bytes, ciphertext: bytes, combined: bytes
+        cls: Type[_EncryptedMessage],
+        nonce: bytes,
+        ciphertext: bytes,
+        combined: bytes,
     ) -> _EncryptedMessage:
         obj = cls(combined)
         obj._nonce = nonce


### PR DESCRIPTION
This applies the changes proposed in #692 to `nacl.utils` on top of the
changes in more recent PRs.

I've annotated `nacl.bindings.randombytes_buf_deterministic` to appease
mypy. It's needed because I configured mypy to require that typed code
always calls typed functions, in #694.

Per https://github.com/pyca/pynacl/pull/692#discussion_r733872525 and
https://stackoverflow.com/a/44644576/5252017 , I've made sure that the
`_from_parts` accepts a generic `cls` argument and returns an instance
of that `cls`. I don't think we actually intend for people to subclass
`EncryptedMessage`, but maybe they do. Besides, it's nice to have
annotations that are as accurate as possible.