### PR TITLE
Only run cron workflow for upstream, not forks

### DIFF
--- a/.github/workflows/lock.yml
+++ b/.github/workflows/lock.yml
@@ -5,6 +5,7 @@ on:
 
 jobs:
   lock:
+    if: github.repository_owner == 'pyca'
     runs-on: ubuntu-latest
     steps:
       - uses: dessant/lock-threads@v3


### PR DESCRIPTION
We don't need to run the cron job to lock old issues on forks.