### PR TITLE
Add support for Python 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,16 +14,17 @@ jobs:
     strategy:
       matrix:
         PYTHON:
-          - {VERSION: "3.9", TOXENV: "docs", COVERAGE: "false"}
-          - {VERSION: "3.9", TOXENV: "meta", COVERAGE: "false"}
-          - {VERSION: "3.9", TOXENV: "mypy", COVERAGE: "false"}
+          - {VERSION: "3.10", TOXENV: "docs", COVERAGE: "false"}
+          - {VERSION: "3.10", TOXENV: "meta", COVERAGE: "false"}
+          - {VERSION: "3.10", TOXENV: "mypy", COVERAGE: "false"}
           - {VERSION: "pypy3", TOXENV: "pypy"}
           - {VERSION: "3.6", TOXENV: "py36"}
           - {VERSION: "3.7", TOXENV: "py37"}
           - {VERSION: "3.8", TOXENV: "py38"}
           - {VERSION: "3.9", TOXENV: "py39"}
-          - {VERSION: "3.9", TOXENV: "py39", NOTE: "system", SODIUM_INSTALL: "system"}
-          - {VERSION: "3.9", TOXENV: "py39", NOTE: "minimal", SODIUM_INSTALL_MINIMAL: "1"}
+          - {VERSION: "3.10", TOXENV: "py310"}
+          - {VERSION: "3.10", TOXENV: "py310", NOTE: "system", SODIUM_INSTALL: "system"}
+          - {VERSION: "3.10", TOXENV: "py310", NOTE: "minimal", SODIUM_INSTALL_MINIMAL: "1"}
     name: "Linux ${{ matrix.PYTHON.TOXENV }} ${{ matrix.PYTHON.NOTE }}"
     steps:
       - uses: actions/checkout@master
@@ -65,8 +66,8 @@ jobs:
       matrix:
         PYTHON:
           - {VERSION: "3.6", TOXENV: "py36"}
-          - {VERSION: "3.9", TOXENV: "py39"}
-          - {VERSION: "3.9", TOXENV: "py39", NOTE: " (minimal build)", SODIUM_INSTALL_MINIMAL: "1"}
+          - {VERSION: "3.10", TOXENV: "py310"}
+          - {VERSION: "3.10", TOXENV: "py310", NOTE: " (minimal build)", SODIUM_INSTALL_MINIMAL: "1"}
     name: "Python ${{ matrix.PYTHON.VERSION }}${{ matrix.PYTHON.NOTE }} on macOS"
     steps:
       - uses: actions/checkout@master
@@ -97,6 +98,7 @@ jobs:
           - {VERSION: "3.7", TOXENV: "py37", SODIUM_MSVC_VERSION: "v142"}
           - {VERSION: "3.8", TOXENV: "py38", SODIUM_MSVC_VERSION: "v142"}
           - {VERSION: "3.9", TOXENV: "py39", SODIUM_MSVC_VERSION: "v142"}
+          - {VERSION: "3.10", TOXENV: "py310", SODIUM_MSVC_VERSION: "v142"}
     name: "Python ${{ matrix.PYTHON.VERSION }} on Windows ${{ matrix.WINDOWS.ARCH }}"
     steps:
       - uses: actions/checkout@master

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
           - {VERSION: "3.10", TOXENV: "docs", COVERAGE: "false"}
           - {VERSION: "3.10", TOXENV: "meta", COVERAGE: "false"}
           - {VERSION: "3.10", TOXENV: "mypy", COVERAGE: "false"}
-          - {VERSION: "pypy3", TOXENV: "pypy"}
+          - {VERSION: "pypy-3.7", TOXENV: "pypy"}
           - {VERSION: "3.6", TOXENV: "py36"}
           - {VERSION: "3.7", TOXENV: "py37"}
           - {VERSION: "3.8", TOXENV: "py38"}

--- a/setup.py
+++ b/setup.py
@@ -232,5 +232,6 @@ setup(
         "Programming Language :: Python :: 3.7",
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pypy,py36,py37,py38,docs,meta,mypy
+envlist = pypy,py36,py37,py38,py39,py310,docs,meta,mypy
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
Python 3.10 was released on 2021-10-04:

* https://discuss.python.org/t/python-3-10-0-is-now-available/10955

---

Also `pypy3` is deprecated and is not available in newer images:
https://github.com/actions/setup-python/issues/244#issuecomment-925966022

Instead explicitly specify the version:
https://github.com/actions/setup-python#specifying-a-pypy-version


---

`wheel-builder.yml` will need some updates too, on a quick glance at least this regex will need fixing for the two digit minor version of 3.10:

https://github.com/pyca/pynacl/blob/6bf77d955788663cb5b4dc9280f71b6d9b5a119e/.github/workflows/wheel-builder.yml#L23

