### PR TITLE
Move `warn_incomplete_stub` to global options

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,6 +16,7 @@ show_error_codes = true
 check_untyped_defs = true
 no_implicit_reexport = true
 warn_redundant_casts = true
+warn_incomplete_stub = true
 
 files = ["src/nacl"]
 
@@ -48,7 +49,6 @@ disallow_untyped_decorators = true
 
 no_implicit_optional = true
 
-warn_incomplete_stub = true
 warn_unused_ignores = true
 warn_no_return = true
 # warn_return_any: true outside of `bindings`


### PR DESCRIPTION
A follow-up to #698.

This suppresses the following warning from mypy, by making the flag
apply globally rather than to a specific module.

```
pyproject.toml: [module = "nacl.bindings.crypto_aead"]: Per-module sections should only specify per-module flags (warn_incomplete_stub)
pyproject.toml: [module = "nacl.encoding"]: Per-module sections should only specify per-module flags (warn_incomplete_stub)
pyproject.toml: [module = "nacl.exceptions"]: Per-module sections should only specify per-module flags (warn_incomplete_stub)
pyproject.toml: [module = "nacl.utils"]: Per-module sections should only specify per-module flags (warn_incomplete_stub)
```