### PR TITLE
Enable stricter checks for `nacl.utils`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -68,6 +68,7 @@ strict_equality = true
 module = [
     "nacl.encoding",
     "nacl.exceptions",
+    "nacl.utils",
 ]
 disallow_any_expr = true
 warn_return_any = true


### PR DESCRIPTION
I think I missed this in #699.