### PR TITLE
Annotations for `nacl.pwhash`.

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,6 +32,7 @@ module = [
     "nacl.bindings",
     "nacl.encoding",
     "nacl.exceptions",
+    "nacl.pwhash",
     "nacl.utils",
 ]
 disallow_any_unimported = true
@@ -68,6 +69,7 @@ module = [
     "nacl.encoding",
     "nacl.exceptions",
     "nacl.utils",
+    "nacl.pwhash",
 ]
 disallow_any_expr = true
 warn_return_any = true

--- a/src/nacl/bindings/crypto_pwhash.py
+++ b/src/nacl/bindings/crypto_pwhash.py
@@ -99,7 +99,7 @@ crypto_pwhash_PASSWD_MAX: int = lib.crypto_pwhash_passwd_max()
 crypto_pwhash_BYTES_MIN: int = lib.crypto_pwhash_bytes_min()
 crypto_pwhash_BYTES_MAX: int = lib.crypto_pwhash_bytes_max()
 
-crypto_pwhash_argon2i_STRPREFIX: str = ffi.string(
+crypto_pwhash_argon2i_STRPREFIX: bytes = ffi.string(
     ffi.cast("char *", lib.crypto_pwhash_argon2i_strprefix())
 )[:]
 crypto_pwhash_argon2i_MEMLIMIT_MIN: int = (
@@ -133,7 +133,7 @@ crypto_pwhash_argon2i_MEMLIMIT_SENSITIVE: int = (
     lib.crypto_pwhash_argon2i_memlimit_sensitive()
 )
 
-crypto_pwhash_argon2id_STRPREFIX: str = ffi.string(
+crypto_pwhash_argon2id_STRPREFIX: bytes = ffi.string(
     ffi.cast("char *", lib.crypto_pwhash_argon2id_strprefix())
 )[:]
 crypto_pwhash_argon2id_MEMLIMIT_MIN: int = (

--- a/src/nacl/pwhash/__init__.py
+++ b/src/nacl/pwhash/__init__.py
@@ -54,7 +54,7 @@ scryptsalsa208sha256_str = scrypt.str
 verify_scryptsalsa208sha256 = scrypt.verify
 
 
-def verify(password_hash, password):
+def verify(password_hash: bytes, password: bytes) -> bool:
     """
     Takes a modular crypt encoded stored password hash derived using one
     of the algorithms supported by `libsodium` and checks if the user provided

--- a/src/nacl/pwhash/_argon2.py
+++ b/src/nacl/pwhash/_argon2.py
@@ -32,7 +32,7 @@ ALG_ARGON2ID13 = nacl.bindings.crypto_pwhash_ALG_ARGON2ID13
 ALG_ARGON2_DEFAULT = nacl.bindings.crypto_pwhash_ALG_DEFAULT
 
 
-def verify(password_hash, password):
+def verify(password_hash: bytes, password: bytes) -> bool:
     """
     Takes a modular crypt encoded argon2i or argon2id stored password hash
     and checks if the user provided password will hash to the same string

--- a/src/nacl/pwhash/argon2i.py
+++ b/src/nacl/pwhash/argon2i.py
@@ -47,13 +47,13 @@ MEMLIMIT_MODERATE = nacl.bindings.crypto_pwhash_argon2i_MEMLIMIT_MODERATE
 
 
 def kdf(
-    size,
-    password,
-    salt,
-    opslimit=OPSLIMIT_SENSITIVE,
-    memlimit=MEMLIMIT_SENSITIVE,
-    encoder=nacl.encoding.RawEncoder,
-):
+    size: int,
+    password: bytes,
+    salt: bytes,
+    opslimit: int = OPSLIMIT_SENSITIVE,
+    memlimit: int = MEMLIMIT_SENSITIVE,
+    encoder: nacl.encoding.Encoder = nacl.encoding.RawEncoder,
+) -> bytes:
     """
     Derive a ``size`` bytes long key from a caller-supplied
     ``password`` and ``salt`` pair using the argon2i
@@ -107,8 +107,10 @@ def kdf(
 
 
 def str(
-    password, opslimit=OPSLIMIT_INTERACTIVE, memlimit=MEMLIMIT_INTERACTIVE
-):
+    password: bytes,
+    opslimit: int = OPSLIMIT_INTERACTIVE,
+    memlimit: int = MEMLIMIT_INTERACTIVE,
+) -> bytes:
     """
     Hashes a password with a random salt, using the memory-hard
     argon2i construct and returning an ascii string that has all

--- a/src/nacl/pwhash/argon2id.py
+++ b/src/nacl/pwhash/argon2id.py
@@ -51,13 +51,13 @@ MEMLIMIT_MODERATE = nacl.bindings.crypto_pwhash_argon2id_MEMLIMIT_MODERATE
 
 
 def kdf(
-    size,
-    password,
-    salt,
-    opslimit=OPSLIMIT_SENSITIVE,
-    memlimit=MEMLIMIT_SENSITIVE,
-    encoder=nacl.encoding.RawEncoder,
-):
+    size: int,
+    password: bytes,
+    salt: bytes,
+    opslimit: int = OPSLIMIT_SENSITIVE,
+    memlimit: int = MEMLIMIT_SENSITIVE,
+    encoder: nacl.encoding.Encoder = nacl.encoding.RawEncoder,
+) -> bytes:
     """
     Derive a ``size`` bytes long key from a caller-supplied
     ``password`` and ``salt`` pair using the argon2i
@@ -111,8 +111,10 @@ def kdf(
 
 
 def str(
-    password, opslimit=OPSLIMIT_INTERACTIVE, memlimit=MEMLIMIT_INTERACTIVE
-):
+    password: bytes,
+    opslimit: int = OPSLIMIT_INTERACTIVE,
+    memlimit: int = MEMLIMIT_INTERACTIVE,
+) -> bytes:
     """
     Hashes a password with a random salt, using the memory-hard
     argon2id construct and returning an ascii string that has all

--- a/src/nacl/pwhash/scrypt.py
+++ b/src/nacl/pwhash/scrypt.py
@@ -56,13 +56,13 @@ MEMLIMIT_MODERATE = 8 * MEMLIMIT_INTERACTIVE
 
 
 def kdf(
-    size,
-    password,
-    salt,
-    opslimit=OPSLIMIT_SENSITIVE,
-    memlimit=MEMLIMIT_SENSITIVE,
-    encoder=nacl.encoding.RawEncoder,
-):
+    size: int,
+    password: bytes,
+    salt: bytes,
+    opslimit: int = OPSLIMIT_SENSITIVE,
+    memlimit: int = MEMLIMIT_SENSITIVE,
+    encoder: nacl.encoding.Encoder = nacl.encoding.RawEncoder,
+) -> bytes:
     """
     Derive a ``size`` bytes long key from a caller-supplied
     ``password`` and ``salt`` pair using the scryptsalsa208sha256
@@ -138,8 +138,10 @@ def kdf(
 
 
 def str(
-    password, opslimit=OPSLIMIT_INTERACTIVE, memlimit=MEMLIMIT_INTERACTIVE
-):
+    password: bytes,
+    opslimit: int = OPSLIMIT_INTERACTIVE,
+    memlimit: int = MEMLIMIT_INTERACTIVE,
+) -> bytes:
     """
     Hashes a password with a random salt, using the memory-hard
     scryptsalsa208sha256 construct and returning an ascii string
@@ -168,7 +170,7 @@ def str(
     )
 
 
-def verify(password_hash, password):
+def verify(password_hash: bytes, password: bytes) -> bool:
     """
     Takes the output of scryptsalsa208sha256 and compares it against
     a user provided password to see if they are the same


### PR DESCRIPTION
Two commits: one which fixes incorrect annotations in `nacl.bindings`, and then the changes from #692 which apply to `nacl.pwhash`. It looks like these were mostly a case of transcribing the types in docstrings to the annotation syntax.