### PR TITLE
Annotations in `tests`, part 1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,15 @@ warn_unreachable = true
 no_implicit_reexport = true
 strict_equality = true
 
-files = ["src/nacl"]
+# Include test files manually for now. Can tidy up later.
+files = [
+    "src/nacl",
+    "tests/test_aead.py",
+    "tests/test_bindings.py",
+    "tests/test_box.py",
+    "tests/test_signing.py",
+    "tests/utils.py",
+]
 
 [[tool.mypy.overrides]]
 module = [
@@ -51,7 +59,7 @@ ignore_missing_imports = true
 # nacl._sodium return `Any` as far as mypy is concerned. It's not worth it to
 # stub the C functions or cast() their uses. But this means there are more
 # `Any`s floating around. So the more restrictive any checks we'd like to use
-# should only be turned out outside of `bindings`.
+# should only be turned on outside of `bindings`.
 
 [[tool.mypy.overrides]]
 module = [
@@ -60,3 +68,23 @@ module = [
 disallow_any_expr = false
 warn_return_any = false
 
+# Loosen some of the checks within the tests.
+# For now this is an explicit list rather than a wildcard "test.*", to make
+# it a little easier to run the strict checks on modules first. We can clean
+# this up later. Note that we _do_ run the strict checks on `test.utils`.
+
+[[tool.mypy.overrides]]
+module = [
+    "tests.test_aead",
+    "tests.test_bindings",
+    "tests.test_box",
+    "tests.test_signing",
+]
+# Some library helpers types' involve `Any`, in particular `pytest.mark.parameterize`
+# and `hypothesis.strategies.sampledfrom`.
+disallow_any_expr = false
+disallow_any_decorated = false
+
+# It's not useful to annotate each test function as `-> None`.
+disallow_untyped_defs = false
+disallow_incomplete_defs = false

--- a/src/nacl/bindings/crypto_scalarmult.py
+++ b/src/nacl/bindings/crypto_scalarmult.py
@@ -20,8 +20,8 @@ from nacl.exceptions import ensure
 
 has_crypto_scalarmult_ed25519 = bool(lib.PYNACL_HAS_CRYPTO_SCALARMULT_ED25519)
 
-crypto_scalarmult_BYTES = lib.crypto_scalarmult_bytes()
-crypto_scalarmult_SCALARBYTES = lib.crypto_scalarmult_scalarbytes()
+crypto_scalarmult_BYTES: int = lib.crypto_scalarmult_bytes()
+crypto_scalarmult_SCALARBYTES: int = lib.crypto_scalarmult_scalarbytes()
 
 crypto_scalarmult_ed25519_BYTES = 0
 crypto_scalarmult_ed25519_SCALARBYTES = 0

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -23,7 +23,7 @@ from nacl.public import Box, PrivateKey, PublicKey
 from nacl.utils import random
 
 from .test_bindings import _box_from_seed_vectors
-
+from .utils import check_type_error
 
 VECTORS = [
     # privalice, pubalice, privbob, pubbob, nonce, plaintext, ciphertext
@@ -340,12 +340,6 @@ def test_box_wrong_length():
         b.encrypt(b"", b"")
     with pytest.raises(ValueError):
         b.decrypt(b"", b"")
-
-
-def check_type_error(expected, f, *args):
-    with pytest.raises(TypeError) as e:
-        f(*args)
-    assert expected in str(e.value)
 
 
 def test_wrong_types():

--- a/tests/test_box.py
+++ b/tests/test_box.py
@@ -61,7 +61,9 @@ def test_generate_private_key_from_random_seed():
 @pytest.mark.parametrize(
     ("seed", "public_key", "secret_key"), _box_from_seed_vectors()
 )
-def test_generate_private_key_from_seed(seed, public_key, secret_key):
+def test_generate_private_key_from_seed(
+    seed: bytes, public_key: bytes, secret_key: bytes
+):
     prvt = PrivateKey.from_seed(seed, encoder=HexEncoder)
     sk = binascii.unhexlify(secret_key)
     pk = binascii.unhexlify(public_key)
@@ -121,12 +123,18 @@ def test_box_bytes():
     VECTORS,
 )
 def test_box_encryption(
-    privalice, pubalice, privbob, pubbob, nonce, plaintext, ciphertext
+    privalice: bytes,
+    pubalice: bytes,
+    privbob: bytes,
+    pubbob: bytes,
+    nonce: bytes,
+    plaintext: bytes,
+    ciphertext: bytes,
 ):
-    pubalice = PublicKey(pubalice, encoder=HexEncoder)
-    privbob = PrivateKey(privbob, encoder=HexEncoder)
+    pubalice_decoded = PublicKey(pubalice, encoder=HexEncoder)
+    privbob_decoded = PrivateKey(privbob, encoder=HexEncoder)
 
-    box = Box(privbob, pubalice)
+    box = Box(privbob_decoded, pubalice_decoded)
     encrypted = box.encrypt(
         binascii.unhexlify(plaintext),
         binascii.unhexlify(nonce),
@@ -155,12 +163,18 @@ def test_box_encryption(
     VECTORS,
 )
 def test_box_decryption(
-    privalice, pubalice, privbob, pubbob, nonce, plaintext, ciphertext
+    privalice: bytes,
+    pubalice: bytes,
+    privbob: bytes,
+    pubbob: bytes,
+    nonce: bytes,
+    plaintext: bytes,
+    ciphertext: bytes,
 ):
-    pubbob = PublicKey(pubbob, encoder=HexEncoder)
-    privalice = PrivateKey(privalice, encoder=HexEncoder)
+    pubbob_decoded = PublicKey(pubbob, encoder=HexEncoder)
+    privalice_decoded = PrivateKey(privalice, encoder=HexEncoder)
 
-    box = Box(privalice, pubbob)
+    box = Box(privalice_decoded, pubbob_decoded)
 
     nonce = binascii.unhexlify(nonce)
     decrypted = binascii.hexlify(
@@ -183,12 +197,18 @@ def test_box_decryption(
     VECTORS,
 )
 def test_box_decryption_combined(
-    privalice, pubalice, privbob, pubbob, nonce, plaintext, ciphertext
+    privalice: bytes,
+    pubalice: bytes,
+    privbob: bytes,
+    pubbob: bytes,
+    nonce: bytes,
+    plaintext: bytes,
+    ciphertext: bytes,
 ):
-    pubbob = PublicKey(pubbob, encoder=HexEncoder)
-    privalice = PrivateKey(privalice, encoder=HexEncoder)
+    pubbob_decoded = PublicKey(pubbob, encoder=HexEncoder)
+    privalice_decoded = PrivateKey(privalice, encoder=HexEncoder)
 
-    box = Box(privalice, pubbob)
+    box = Box(privalice_decoded, pubbob_decoded)
 
     combined = binascii.hexlify(
         binascii.unhexlify(nonce) + binascii.unhexlify(ciphertext),
@@ -211,12 +231,18 @@ def test_box_decryption_combined(
     VECTORS,
 )
 def test_box_optional_nonce(
-    privalice, pubalice, privbob, pubbob, nonce, plaintext, ciphertext
+    privalice: bytes,
+    pubalice: bytes,
+    privbob: bytes,
+    pubbob: bytes,
+    nonce: bytes,
+    plaintext: bytes,
+    ciphertext: bytes,
 ):
-    pubbob = PublicKey(pubbob, encoder=HexEncoder)
-    privalice = PrivateKey(privalice, encoder=HexEncoder)
+    pubbob_decoded = PublicKey(pubbob, encoder=HexEncoder)
+    privalice_decoded = PrivateKey(privalice, encoder=HexEncoder)
 
-    box = Box(privalice, pubbob)
+    box = Box(privalice_decoded, pubbob_decoded)
 
     encrypted = box.encrypt(binascii.unhexlify(plaintext), encoder=HexEncoder)
 
@@ -238,12 +264,18 @@ def test_box_optional_nonce(
     VECTORS,
 )
 def test_box_encryption_generates_different_nonces(
-    privalice, pubalice, privbob, pubbob, nonce, plaintext, ciphertext
+    privalice: bytes,
+    pubalice: bytes,
+    privbob: bytes,
+    pubbob: bytes,
+    nonce: bytes,
+    plaintext: bytes,
+    ciphertext: bytes,
 ):
-    pubbob = PublicKey(pubbob, encoder=HexEncoder)
-    privalice = PrivateKey(privalice, encoder=HexEncoder)
+    pubbob_decoded = PublicKey(pubbob, encoder=HexEncoder)
+    privalice_decoded = PrivateKey(privalice, encoder=HexEncoder)
 
-    box = Box(privalice, pubbob)
+    box = Box(privalice_decoded, pubbob_decoded)
 
     nonce_0 = box.encrypt(
         binascii.unhexlify(plaintext), encoder=HexEncoder
@@ -269,14 +301,20 @@ def test_box_encryption_generates_different_nonces(
     VECTORS,
 )
 def test_box_failed_decryption(
-    privalice, pubalice, privbob, pubbob, nonce, plaintext, ciphertext
+    privalice: bytes,
+    pubalice: bytes,
+    privbob: bytes,
+    pubbob: bytes,
+    nonce: bytes,
+    plaintext: bytes,
+    ciphertext: bytes,
 ):
-    pubbob = PublicKey(pubbob, encoder=HexEncoder)
-    privbob = PrivateKey(privbob, encoder=HexEncoder)
+    pubbob_decoded = PublicKey(pubbob, encoder=HexEncoder)
+    privbob_decoded = PrivateKey(privbob, encoder=HexEncoder)
 
     # this cannot decrypt the ciphertext! the ciphertext must be decrypted by
     # (privalice, pubbob) or (privbob, pubalice)
-    box = Box(privbob, pubbob)
+    box = Box(privbob_decoded, pubbob_decoded)
 
     with pytest.raises(CryptoError):
         box.decrypt(ciphertext, binascii.unhexlify(nonce), encoder=HexEncoder)
@@ -285,6 +323,7 @@ def test_box_failed_decryption(
 def test_box_wrong_length():
     with pytest.raises(ValueError):
         PublicKey(b"")
+    # TODO: should the below raise a ValueError?
     with pytest.raises(TypeError):
         PrivateKey(b"")
 

--- a/tests/test_sealed_box.py
+++ b/tests/test_sealed_box.py
@@ -21,7 +21,7 @@ from nacl.encoding import HexEncoder
 from nacl.exceptions import CryptoError
 from nacl.public import PrivateKey, PublicKey, SealedBox
 
-from .utils import read_crypto_test_vectors
+from .utils import check_type_error, read_crypto_test_vectors
 
 
 def sealbox_vectors():
@@ -95,12 +95,6 @@ def test_sealed_box_decryption(privalice, pubalice, plaintext, encrypted):
         encoder=HexEncoder,
     )
     assert binascii.hexlify(decrypted) == plaintext
-
-
-def check_type_error(expected, f, *args):
-    with pytest.raises(TypeError) as e:
-        f(*args)
-    assert expected in str(e.value)
 
 
 def test_wrong_types():

--- a/tests/test_signing.py
+++ b/tests/test_signing.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import binascii
-from typing import Callable, List, Tuple, Union
+from typing import List, Tuple, Union
 
 import pytest
 
@@ -21,7 +21,12 @@ from nacl.encoding import Base64Encoder, HexEncoder
 from nacl.exceptions import BadSignatureError
 from nacl.signing import SignedMessage, SigningKey, VerifyKey
 
-from .utils import assert_equal, assert_not_equal, read_crypto_test_vectors
+from .utils import (
+    assert_equal,
+    assert_not_equal,
+    check_type_error,
+    read_crypto_test_vectors,
+)
 
 
 def tohex(b: bytes) -> str:
@@ -267,16 +272,6 @@ class TestVerifyKey:
             "f1814f0e8ff1043d8a44d25babff3ced"
             "cae6c22c3edaa48f857ae70de2baae50"
         )
-
-
-# Type safety: it's fine to use `...` here, but mypy config doesn't like it because it's
-# an explict `Any`.
-def check_type_error(  # type: ignore[misc]
-    expected: str, f: Callable[..., object], *args: object
-) -> None:
-    with pytest.raises(TypeError) as e:
-        f(*args)
-    assert expected in str(e.value)
 
 
 def test_wrong_types():

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -14,7 +14,9 @@
 
 
 import os
-from typing import Dict, List, Optional, Tuple
+from typing import Callable, Dict, List, Optional, Tuple
+
+import pytest
 
 
 def assert_equal(x: object, y: object) -> None:
@@ -74,3 +76,13 @@ def flip_byte(original: bytes, byte_offset: int) -> bytes:
         + bytes([0x01 ^ original[byte_offset]])
         + original[byte_offset + 1 :]
     )
+
+
+# Type safety: it's fine to use `...` here, but mypy config doesn't like it because it's
+# an explict `Any`.
+def check_type_error(  # type: ignore[misc]
+    expected: str, f: Callable[..., object], *args: object
+) -> None:
+    with pytest.raises(TypeError) as e:
+        f(*args)
+    assert expected in str(e.value)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -14,19 +14,22 @@
 
 
 import os
+from typing import Dict, List, Optional, Tuple
 
 
-def assert_equal(x, y):
+def assert_equal(x: object, y: object) -> None:
     assert x == y
     assert not (x != y)
 
 
-def assert_not_equal(x, y):
+def assert_not_equal(x: object, y: object) -> None:
     assert x != y
     assert not (x == y)
 
 
-def read_crypto_test_vectors(fname, maxels=0, delimiter=None):
+def read_crypto_test_vectors(
+    fname: str, maxels: int = 0, delimiter: Optional[bytes] = None
+) -> List[Tuple[bytes, ...]]:
     assert delimiter is not None and isinstance(delimiter, bytes)
     vectors = []
     path = os.path.join(os.path.dirname(__file__), "data", fname)
@@ -41,12 +44,16 @@ def read_crypto_test_vectors(fname, maxels=0, delimiter=None):
     return vectors
 
 
-def read_kv_test_vectors(fname, delimiter=None, newrecord=None):
+def read_kv_test_vectors(
+    fname: str,
+    delimiter: Optional[bytes] = None,
+    newrecord: Optional[bytes] = None,
+) -> List[Dict[str, bytes]]:
     assert delimiter is not None and isinstance(delimiter, bytes)
     assert newrecord is not None and isinstance(newrecord, bytes)
     vectors = []
     path = os.path.join(os.path.dirname(__file__), "data", fname)
-    vector = {}
+    vector: Dict[str, bytes] = {}
     with open(path, "rb") as fp:
         for line in fp:
             line = line.rstrip()
@@ -61,7 +68,7 @@ def read_kv_test_vectors(fname, delimiter=None, newrecord=None):
     return vectors
 
 
-def flip_byte(original, byte_offset):
+def flip_byte(original: bytes, byte_offset: int) -> bytes:
     return (
         original[:byte_offset]
         + bytes([0x01 ^ original[byte_offset]])


### PR DESCRIPTION
~~Draft for now while CI runs. ~~

I started by adding annotations to `tests.utils` like I did the rest of the project, using the same strict config as before. Then I took a few modules and ran mypy on them, and dealt with any unexpected complaints reported by mypy. Then I suppressed the uninteresting errors in mypy config.

Its complaints so far:
* test functions aren't annotated. For simple functions this is just `disallow_untyped_defs` being unhappy that we haven't marked test function as `-> None`. There are some parameterised tests though, and I found it useful to add in annotations here to ensure the test body was doing something sensible.
  * FWIW I wouldn't be against adding the `-> None`
* decorators from pytest and hypothesis return functions whose type involves `Any`. Not interesting; ignored in config.
* Mypy spotted that `crypto_scalarmult_BYTES` and `SCALARBYTES` were untyped, see 10434eb. Easy to fix.
* Also in 10434eb, we were calling `crypto_box` with a string `nonce`. I'm a bit surprised this worked, to be honest. I guess the fact that the nonce was ascii-encodable (i.e. just nulls) might have helped? 

I didn't feel like annotating `check_type_error` three times, so I pulled it out to `tests.utils`. It's a bit naughty to do so in this PR (could spin it out?) and I felt a bit icky making `utils` pull in `pytest`.