### PR TITLE
Mark size constants as `ClassVar`s

### DIFF
--- a/src/nacl/public.py
+++ b/src/nacl/public.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Generic, Optional, Type, TypeVar
+from typing import ClassVar, Generic, Optional, Type, TypeVar
 
 import nacl.bindings
 from nacl import encoding
@@ -31,7 +31,7 @@ class PublicKey(encoding.Encodable, StringFixer):
     :cvar SIZE: The size that the public key is required to be
     """
 
-    SIZE = nacl.bindings.crypto_box_PUBLICKEYBYTES
+    SIZE: ClassVar[int] = nacl.bindings.crypto_box_PUBLICKEYBYTES
 
     def __init__(
         self,
@@ -81,8 +81,8 @@ class PrivateKey(encoding.Encodable, StringFixer):
                      private key is required to be
     """
 
-    SIZE = nacl.bindings.crypto_box_SECRETKEYBYTES
-    SEED_SIZE = nacl.bindings.crypto_box_SEEDBYTES
+    SIZE: ClassVar[int] = nacl.bindings.crypto_box_SECRETKEYBYTES
+    SEED_SIZE: ClassVar[int] = nacl.bindings.crypto_box_SEEDBYTES
 
     def __init__(
         self,
@@ -190,7 +190,7 @@ class Box(encoding.Encodable, StringFixer):
     :cvar NONCE_SIZE: The size that the nonce is required to be.
     """
 
-    NONCE_SIZE = nacl.bindings.crypto_box_NONCEBYTES
+    NONCE_SIZE: ClassVar[int] = nacl.bindings.crypto_box_NONCEBYTES
     _shared_key: bytes
 
     def __init__(self, private_key: PrivateKey, public_key: PublicKey):

--- a/src/nacl/secret.py
+++ b/src/nacl/secret.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional
+from typing import ClassVar, Optional
 
 import nacl.bindings
 from nacl import encoding
@@ -49,10 +49,12 @@ class SecretBox(encoding.Encodable, StringFixer):
                             pair.
     """
 
-    KEY_SIZE = nacl.bindings.crypto_secretbox_KEYBYTES
-    NONCE_SIZE = nacl.bindings.crypto_secretbox_NONCEBYTES
-    MACBYTES = nacl.bindings.crypto_secretbox_MACBYTES
-    MESSAGEBYTES_MAX = nacl.bindings.crypto_secretbox_MESSAGEBYTES_MAX
+    KEY_SIZE: ClassVar[int] = nacl.bindings.crypto_secretbox_KEYBYTES
+    NONCE_SIZE: ClassVar[int] = nacl.bindings.crypto_secretbox_NONCEBYTES
+    MACBYTES: ClassVar[int] = nacl.bindings.crypto_secretbox_MACBYTES
+    MESSAGEBYTES_MAX: ClassVar[
+        int
+    ] = nacl.bindings.crypto_secretbox_MESSAGEBYTES_MAX
 
     def __init__(
         self, key: bytes, encoder: encoding.Encoder = encoding.RawEncoder


### PR DESCRIPTION
I guess I wasn't looking out for this before since there weren't any
mypy errors. Nice to have though.