### PR TITLE
Mypy tests 3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -6,6 +6,7 @@ Changelog
 
 * **BACKWARDS INCOMPATIBLE:** Removed support for Python 2.7 and Python 3.5.
 * Update ``libsodium`` to 1.0.18-stable (July 25, 2021 release).
+* Add inline type hints.
 
 1.4.0 (2020-05-25)
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,27 +39,9 @@ warn_unreachable = true
 no_implicit_reexport = true
 strict_equality = true
 
-# Include test files manually for now. Can tidy up later.
 files = [
     "src/nacl",
-    "tests/test_aead.py",
-    "tests/test_bindings.py",
-    "tests/test_box.py",
-    "tests/test_encoding.py",
-    "tests/test_exc.py",
-    "tests/test_generichash.py",
-    "tests/test_hash.py",
-    "tests/test_hashlib_scrypt.py",
-    "tests/test_kx.py",
-    "tests/test_public.py",
-    "tests/test_pwhash.py",
-    "tests/test_sealed_box.py",
-    "tests/test_secret.py",
-    "tests/test_secretstream.py",
-    "tests/test_shorthash.py",
-    "tests/test_signing.py",
-    "tests/test_utils.py",
-    "tests/utils.py",
+    "tests",
 ]
 
 [[tool.mypy.overrides]]
@@ -81,30 +63,13 @@ module = [
 disallow_any_expr = false
 warn_return_any = false
 
-# Loosen some of the checks within the tests.
-# For now this is an explicit list rather than a wildcard "test.*", to make
-# it a little easier to run the strict checks on modules first. We can clean
-# this up later. Note that we _do_ run the strict checks on `test.utils`.
+# Loosen some of the checks within the tests. Note that `tests.utils` passes with the
+# strict checks on, but it's included here in the list of modules with looser checks
+# to keep mypy's config simple(r).
 
 [[tool.mypy.overrides]]
 module = [
-    "tests.test_aead",
-    "tests.test_bindings",
-    "tests.test_box",
-    "tests.test_encoding",
-    "tests.test_exc",
-    "tests.test_generichash",
-    "tests.test_hash",
-    "tests.test_hashlib_scrypt",
-    "tests.test_kx",
-    "tests.test_public",
-    "tests.test_pwhash",
-    "tests.test_signing",
-    "tests.test_sealed_box",
-    "tests.test_secret",
-    "tests.test_secretstream",
-    "tests.test_shorthash",
-    "tests.test_utils",
+    "tests.*",
 ]
 # Some library helpers types' involve `Any`, in particular `pytest.mark.parameterize`
 # and `hypothesis.strategies.sampledfrom`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,6 +53,7 @@ files = [
     "tests/test_kx.py",
     "tests/test_public.py",
     "tests/test_pwhash.py",
+    "tests/test_sealed_box.py",
     "tests/test_signing.py",
     "tests/utils.py",
 ]
@@ -95,6 +96,7 @@ module = [
     "tests.test_public",
     "tests.test_pwhash",
     "tests.test_signing",
+    "tests.test_sealed_box",
 ]
 # Some library helpers types' involve `Any`, in particular `pytest.mark.parameterize`
 # and `hypothesis.strategies.sampledfrom`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -55,6 +55,7 @@ files = [
     "tests/test_pwhash.py",
     "tests/test_sealed_box.py",
     "tests/test_secret.py",
+    "tests/test_secretstream.py",
     "tests/test_signing.py",
     "tests/utils.py",
 ]
@@ -99,6 +100,7 @@ module = [
     "tests.test_signing",
     "tests.test_sealed_box",
     "tests.test_secret",
+    "tests.test_secretstream",
 ]
 # Some library helpers types' involve `Any`, in particular `pytest.mark.parameterize`
 # and `hypothesis.strategies.sampledfrom`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ files = [
     "tests/test_public.py",
     "tests/test_pwhash.py",
     "tests/test_sealed_box.py",
+    "tests/test_secret.py",
     "tests/test_signing.py",
     "tests/utils.py",
 ]
@@ -97,6 +98,7 @@ module = [
     "tests.test_pwhash",
     "tests.test_signing",
     "tests.test_sealed_box",
+    "tests.test_secret",
 ]
 # Some library helpers types' involve `Any`, in particular `pytest.mark.parameterize`
 # and `hypothesis.strategies.sampledfrom`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,6 +56,7 @@ files = [
     "tests/test_sealed_box.py",
     "tests/test_secret.py",
     "tests/test_secretstream.py",
+    "tests/test_shorthash.py",
     "tests/test_signing.py",
     "tests/utils.py",
 ]
@@ -101,6 +102,7 @@ module = [
     "tests.test_sealed_box",
     "tests.test_secret",
     "tests.test_secretstream",
+    "tests.test_shorthash",
 ]
 # Some library helpers types' involve `Any`, in particular `pytest.mark.parameterize`
 # and `hypothesis.strategies.sampledfrom`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -58,6 +58,7 @@ files = [
     "tests/test_secretstream.py",
     "tests/test_shorthash.py",
     "tests/test_signing.py",
+    "tests/test_utils.py",
     "tests/utils.py",
 ]
 
@@ -103,6 +104,7 @@ module = [
     "tests.test_secret",
     "tests.test_secretstream",
     "tests.test_shorthash",
+    "tests.test_utils",
 ]
 # Some library helpers types' involve `Any`, in particular `pytest.mark.parameterize`
 # and `hypothesis.strategies.sampledfrom`.

--- a/src/nacl/bindings/crypto_secretstream.py
+++ b/src/nacl/bindings/crypto_secretstream.py
@@ -73,13 +73,15 @@ class crypto_secretstream_xchacha20poly1305_state:
 
     def __init__(self) -> None:
         """Initialize a clean state object."""
-        self.statebuf = ffi.new(
+        # NOTE: the members below aren't `bytearray` objects, but cffi `cdata` objects
+        # which own an array of unsigned chars. Is there a better annotation?
+        self.statebuf: bytearray = ffi.new(
             "unsigned char[]",
             crypto_secretstream_xchacha20poly1305_STATEBYTES,
         )
 
-        self.rawbuf: Optional[bytes] = None
-        self.tagbuf: Optional[bytes] = None
+        self.rawbuf: Optional[bytearray] = None
+        self.tagbuf: Optional[bytearray] = None
 
 
 def crypto_secretstream_xchacha20poly1305_init_push(

--- a/src/nacl/bindings/crypto_secretstream.py
+++ b/src/nacl/bindings/crypto_secretstream.py
@@ -11,7 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from typing import Optional, Tuple, cast
+from typing import ByteString, Optional, Tuple, cast
 
 from nacl import exceptions as exc
 from nacl._sodium import ffi, lib
@@ -73,15 +73,13 @@ class crypto_secretstream_xchacha20poly1305_state:
 
     def __init__(self) -> None:
         """Initialize a clean state object."""
-        # NOTE: the members below aren't `bytearray` objects, but cffi `cdata` objects
-        # which own an array of unsigned chars. Is there a better annotation?
-        self.statebuf: bytearray = ffi.new(
+        self.statebuf: ByteString = ffi.new(
             "unsigned char[]",
             crypto_secretstream_xchacha20poly1305_STATEBYTES,
         )
 
-        self.rawbuf: Optional[bytearray] = None
-        self.tagbuf: Optional[bytearray] = None
+        self.rawbuf: Optional[ByteString] = None
+        self.tagbuf: Optional[ByteString] = None
 
 
 def crypto_secretstream_xchacha20poly1305_init_push(

--- a/tests/test_secretstream.py
+++ b/tests/test_secretstream.py
@@ -12,11 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-
 import binascii
 import json
 import os
 import random
+from typing import List, Optional, Tuple
+
+from _pytest._code import ExceptionInfo
+from _pytest.monkeypatch import MonkeyPatch
 
 import pytest
 
@@ -40,27 +43,29 @@ from nacl.bindings.crypto_secretstream import (
 )
 from nacl.utils import random as randombytes
 
+Chunk = Tuple[int, Optional[bytes], bytes, bytes]
 
-def read_secretstream_vectors():
+
+def read_secretstream_vectors() -> List[Tuple[bytes, bytes, List[Chunk]]]:
     DATA = "secretstream-test-vectors.json"
     path = os.path.join(os.path.dirname(__file__), "data", DATA)
     with open(path) as fp:
         jvectors = json.load(fp)
     unhex = binascii.unhexlify
     vectors = [
-        [
+        (
             unhex(v["key"]),
             unhex(v["header"]),
             [
-                [
+                (
                     c["tag"],
                     unhex(c["ad"]) if c["ad"] is not None else None,
                     unhex(c["message"]),
                     unhex(c["ciphertext"]),
-                ]
+                )
                 for c in v["chunks"]
             ],
-        ]
+        )
         for v in jvectors
     ]
     return vectors
@@ -70,7 +75,7 @@ def read_secretstream_vectors():
     ("key", "header", "chunks"),
     read_secretstream_vectors(),
 )
-def test_vectors(key, header, chunks):
+def test_vectors(key: bytes, header: bytes, chunks: List[Chunk]):
     state = crypto_secretstream_xchacha20poly1305_state()
     crypto_secretstream_xchacha20poly1305_init_pull(state, header, key)
     for tag, ad, message, ciphertext in chunks:
@@ -130,6 +135,11 @@ def test_it_like_libsodium():
     m2, tag = crypto_secretstream_xchacha20poly1305_pull(state, c2, ad)
     assert tag == crypto_secretstream_xchacha20poly1305_TAG_MESSAGE
     assert m2 == m2_
+
+    # Mark this as taking a generic Exception, or else mypy will later complain
+    # that we can't write an ExceptionInfo[ValueError] value to an expression of type
+    # ExceptionInfo[RuntimeError].
+    excinfo: ExceptionInfo[Exception]
 
     with pytest.raises(RuntimeError) as excinfo:
         crypto_secretstream_xchacha20poly1305_pull(state, c3)
@@ -209,7 +219,8 @@ def test_it_like_libsodium():
 
     header = crypto_secretstream_xchacha20poly1305_init_push(state, k)
 
-    state_save = ffi.buffer(state.statebuf)[:]
+    # TODO: not strictly a bytes object: see crypto_secretstream_xchacha20poly1305_state
+    state_save: bytearray = ffi.buffer(state.statebuf)[:]
 
     c1 = crypto_secretstream_xchacha20poly1305_push(
         state, m1, tag=crypto_secretstream_xchacha20poly1305_TAG_REKEY
@@ -251,7 +262,7 @@ def test_it_like_libsodium():
     # to test the nonce as we're using an opaque pointer
 
 
-def test_max_message_size(monkeypatch):
+def test_max_message_size(monkeypatch: MonkeyPatch):
     import nacl.bindings.crypto_secretstream as css
 
     # we want to create an oversized message but don't want to blow out

--- a/tests/test_shorthash.py
+++ b/tests/test_shorthash.py
@@ -14,6 +14,7 @@
 
 
 from binascii import hexlify
+from typing import List, Tuple
 
 import pytest
 
@@ -168,7 +169,7 @@ XHASHES = [
 ]
 
 
-def sip24_vectors():
+def sip24_vectors() -> List[Tuple[bytes, bytes, bytes]]:
     """Generate test vectors using data from the reference implementation's
     test defined in  https://github.com/veorq/SipHash/blob/master/main.c
 
@@ -182,7 +183,7 @@ def sip24_vectors():
     return vectors
 
 
-def sipx24_vectors():
+def sipx24_vectors() -> List[Tuple[bytes, bytes, bytes]]:
     """Generate test vectors using data from libsodium's tests"""
     vectors = []
     for i, expected in enumerate(XHASHES):
@@ -192,7 +193,7 @@ def sipx24_vectors():
 
 
 @pytest.mark.parametrize(("inp", "key", "expected"), sip24_vectors())
-def test_siphash24(inp, key, expected):
+def test_siphash24(inp: bytes, key: bytes, expected: bytes):
     rs = siphash24(inp, key)
     assert rs == hexlify(expected)
 
@@ -201,7 +202,7 @@ def test_siphash24(inp, key, expected):
     not SIPHASHX_AVAILABLE, reason="Requires full build of libsodium"
 )
 @pytest.mark.parametrize(("inp", "key", "expected"), sipx24_vectors())
-def test_siphashx24(inp, key, expected):
+def test_siphashx24(inp: bytes, key: bytes, expected: bytes):
     rs = siphashx24(inp, key)
     assert rs == expected
 
@@ -210,7 +211,7 @@ def test_siphashx24(inp, key, expected):
     ("inp", "key", "expected"),
     [(b"\00", b"\x00\x01\x02\x03\x04\x05\x06\x07", b"")],
 )
-def test_siphash24_shortened_key(inp, key, expected):
+def test_siphash24_shortened_key(inp: bytes, key: bytes, expected: bytes):
     with pytest.raises(ValueError):
         siphash24(inp, key)
 
@@ -222,7 +223,7 @@ def test_siphash24_shortened_key(inp, key, expected):
     ("inp", "key", "expected"),
     [(b"\00", b"\x00\x01\x02\x03\x04\x05\x06\x07", b"")],
 )
-def test_siphashx24_shortened_key(inp, key, expected):
+def test_siphashx24_shortened_key(inp: bytes, key: bytes, expected: bytes):
     with pytest.raises(ValueError):
         siphashx24(inp, key)
 


### PR DESCRIPTION
Also a draft. Branches off from #728; the first new commit is 
8cfeced. I'm just sticking this up to get CI to run on the proposed final batch of annotations to `tests` now.

Also, while I'm at it, I wanted to see if we could quantify how much has changed with all this typing. To do so:

```
git checkout mypy-tests-3
mypy --html-report out --any-exprs-report out
xdg-open out/index.html
less out/any-exprs.txt

git checkout ee93f9f13e4ce803a707b972d0fbc324439e71fc
git restore --source=mypy-tests-3 pyproject.toml
mypy --html-report out_old --any-exprs-report out_old
xdg-open out_old/index.html
less out_old/any-exprs.txt
```

TL:DR:

* Before: 55% of expressions were not Any. Mypy deemed the project as a whole 33% imprecise.
* After: 83% of expressions are not Any. Project as a whole deemed 12% imprecise.

(These numbers from the any-exprs and html reports, respectively).

I think most of that comes down to cffi in `nacl`; maybe some bits in tests from `json.loads()`.

If we just look at the higher level stuff outside of `nacl.bindings`, the numbers are rosier:

```
$ less out/any-exprs.txt | \grep nacl | \grep -v bindings 
                             nacl      0      19    100.00%
                    nacl.encoding      0      70    100.00%
                  nacl.exceptions      0      27    100.00%
                        nacl.hash      0     105    100.00%
                     nacl.hashlib      0     137    100.00%
                      nacl.public      5     489     98.98%
                      nacl.pwhash      0      85    100.00%
              nacl.pwhash._argon2      0      31    100.00%
              nacl.pwhash.argon2i      0      71    100.00%
             nacl.pwhash.argon2id      0      71    100.00%
               nacl.pwhash.scrypt      1     129     99.22%
                      nacl.secret      2     276     99.28%
                     nacl.signing      6     278     97.84%
                       nacl.utils      0      59    100.00%
```
