### PR TITLE
Add support for Python 3.11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,17 +14,18 @@ jobs:
     strategy:
       matrix:
         PYTHON:
-          - {VERSION: "3.10", TOXENV: "docs", COVERAGE: "false"}
-          - {VERSION: "3.10", TOXENV: "meta", COVERAGE: "false"}
-          - {VERSION: "3.10", TOXENV: "mypy", COVERAGE: "false"}
+          - {VERSION: "3.11", TOXENV: "docs", COVERAGE: "false"}
+          - {VERSION: "3.11", TOXENV: "meta", COVERAGE: "false"}
+          - {VERSION: "3.11", TOXENV: "mypy", COVERAGE: "false"}
           - {VERSION: "pypy-3.7", TOXENV: "pypy"}
           - {VERSION: "3.6", TOXENV: "py36"}
           - {VERSION: "3.7", TOXENV: "py37"}
           - {VERSION: "3.8", TOXENV: "py38"}
           - {VERSION: "3.9", TOXENV: "py39"}
           - {VERSION: "3.10", TOXENV: "py310"}
-          - {VERSION: "3.10", TOXENV: "py310", NOTE: "system", SODIUM_INSTALL: "system"}
-          - {VERSION: "3.10", TOXENV: "py310", NOTE: "minimal", SODIUM_INSTALL_MINIMAL: "1"}
+          - {VERSION: "3.11", TOXENV: "py311"}
+          - {VERSION: "3.11", TOXENV: "py311", NOTE: "system", SODIUM_INSTALL: "system"}
+          - {VERSION: "3.11", TOXENV: "py311", NOTE: "minimal", SODIUM_INSTALL_MINIMAL: "1"}
     name: "Linux ${{ matrix.PYTHON.TOXENV }} ${{ matrix.PYTHON.NOTE }}"
     steps:
       - uses: actions/checkout@v3.0.2
@@ -66,8 +67,8 @@ jobs:
       matrix:
         PYTHON:
           - {VERSION: "3.6", TOXENV: "py36"}
-          - {VERSION: "3.10", TOXENV: "py310"}
-          - {VERSION: "3.10", TOXENV: "py310", NOTE: " (minimal build)", SODIUM_INSTALL_MINIMAL: "1"}
+          - {VERSION: "3.11", TOXENV: "py311"}
+          - {VERSION: "3.11", TOXENV: "py311", NOTE: " (minimal build)", SODIUM_INSTALL_MINIMAL: "1"}
     name: "Python ${{ matrix.PYTHON.VERSION }}${{ matrix.PYTHON.NOTE }} on macOS"
     steps:
       - uses: actions/checkout@v3.0.2
@@ -99,6 +100,7 @@ jobs:
           - {VERSION: "3.8", TOXENV: "py38", SODIUM_MSVC_VERSION: "v142"}
           - {VERSION: "3.9", TOXENV: "py39", SODIUM_MSVC_VERSION: "v142"}
           - {VERSION: "3.10", TOXENV: "py310", SODIUM_MSVC_VERSION: "v142"}
+          - {VERSION: "3.11", TOXENV: "py311", SODIUM_MSVC_VERSION: "v142"}
     name: "Python ${{ matrix.PYTHON.VERSION }} on Windows ${{ matrix.WINDOWS.ARCH }}"
     steps:
       - uses: actions/checkout@v3.0.2

--- a/setup.py
+++ b/setup.py
@@ -230,5 +230,6 @@ setup(
         "Programming Language :: Python :: 3.8",
         "Programming Language :: Python :: 3.9",
         "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
     ],
 )

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = pypy,py36,py37,py38,py39,py310,docs,meta,mypy
+envlist = py{py,36,37,38,39,310,311},docs,meta,mypy
 isolated_build = True
 
 [testenv]


### PR DESCRIPTION
Python 3.11 was [released on 2022-10-24](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk) 🚀 

[![image](https://user-images.githubusercontent.com/1324225/198233993-5b79523b-370f-4316-a4be-9403c8209068.png)](https://discuss.python.org/t/python-3-11-0-final-is-now-available/20291?u=hugovk)