### PR TITLE
Update deprecated configuration in `setup.cfg`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [metadata]
-license_file = LICENSE
+license_files = LICENSE


### PR DESCRIPTION
Please note that the use of `license_file` is deprecated. It is recommended to use `license_files`.
Another alternative is just to remove this configuration, because setuptools will automatically add files that match `LICEN[CS]E*`.