### PR TITLE
Update argon2id.py

### DIFF
--- a/src/nacl/pwhash/argon2id.py
+++ b/src/nacl/pwhash/argon2id.py
@@ -60,7 +60,7 @@ def kdf(
 ) -> bytes:
     """
     Derive a ``size`` bytes long key from a caller-supplied
-    ``password`` and ``salt`` pair using the argon2i
+    ``password`` and ``salt`` pair using the argon2id
     memory-hard construct.
 
     the enclosing module provides the constants


### PR DESCRIPTION
Fix typo in docs: kdf() function provides argon2id construction, not argon2i.