### PR TITLE
Add "Bug Tracker" and "Documentation" links to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,6 +44,11 @@ docs = [
     "sphinx_rtd_theme"
 ]
 
+[project.urls]
+"Homepage" = "https://github.com/pyca/pynacl"
+"Bug Tracker" = "https://github.com/pyca/pynacl/issues"
+"Documentation" = "https://pynacl.readthedocs.io"
+
 [tool.black]
 line-length = 79
 target-version = ["py36"]


### PR DESCRIPTION
They show up on the pypi page on the left, making them easier to find.

Based on:
https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#urls