### PR TITLE
Build bindings reproducibly

### DIFF
--- a/src/bindings/build.py
+++ b/src/bindings/build.py
@@ -22,12 +22,16 @@ from cffi import FFI
 __all__ = ["ffi"]
 
 
-HEADERS = glob.glob(
-    os.path.join(os.path.abspath(os.path.dirname(__file__)), "*.h")
+HEADERS = sorted(
+    glob.glob(os.path.join(os.path.abspath(os.path.dirname(__file__)), "*.h"))
 )
 
-MINIMAL_HEADERS = glob.glob(
-    os.path.join(os.path.abspath(os.path.dirname(__file__)), "minimal", "*.h")
+MINIMAL_HEADERS = sorted(
+    glob.glob(
+        os.path.join(
+            os.path.abspath(os.path.dirname(__file__)), "minimal", "*.h"
+        )
+    )
 )
 
 


### PR DESCRIPTION
`glob` output isn't guaranteed to be in any particular order, so `_sodium.*.so` wasn't always reproducible.