### PR TITLE
Fix docs build

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -99,7 +99,6 @@ pygments_style = "sphinx"
 # a list of builtin themes.
 if sphinx_rtd_theme:
     html_theme = "sphinx_rtd_theme"
-    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
 else:
     html_theme = "default"
 


### PR DESCRIPTION
```pytb
Running Sphinx v6.2.1

Configuration error:
There is a programmable error in your configuration file:

Traceback (most recent call last):
  File "/home/runner/work/pynacl/pynacl/.tox/docs/lib/python3.12/site-packages/sphinx/config.py", line 354, in eval_config_file
    exec(code, namespace)  # NoQA: S102
    ^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/pynacl/pynacl/docs/conf.py", line 102, in <module>
    html_theme_path = [sphinx_rtd_theme.get_html_theme_path()]
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/runner/work/pynacl/pynacl/.tox/docs/lib/python3.12/site-packages/sphinx_rtd_theme/__init__.py", line 24, in get_html_theme_path
    logger.warning(
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/logging/__init__.py", line 19[30](https://github.com/hugovk/pynacl/actions/runs/11213420559/job/31166435352#step:6:31), in warning
    self.log(WARNING, msg, *args, **kwargs)
  File "/home/runner/work/pynacl/pynacl/.tox/docs/lib/python3.12/site-packages/sphinx/util/logging.py", line 124, in log
    super().log(level, msg, *args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/logging/__init__.py", line 1962, in log
    self.logger.log(level, msg, *args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/logging/__init__.py", line 1609, in log
    self._log(level, msg, args, **kwargs)
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/logging/__init__.py", line 1684, in _log
    self.handle(record)
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/logging/__init__.py", line 1700, in handle
    self.callHandlers(record)
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/logging/__init__.py", line 1762, in callHandlers
    hdlr.handle(record)
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/logging/__init__.py", line 1022, in handle
    rv = self.filter(record)
         ^^^^^^^^^^^^^^^^^^^
  File "/opt/hostedtoolcache/Python/3.12.6/x64/lib/python3.12/logging/__init__.py", line 858, in filter
    result = f.filter(record)
             ^^^^^^^^^^^^^^^^
  File "/home/runner/work/pynacl/pynacl/.tox/docs/lib/python3.12/site-packages/sphinx/util/logging.py", line [42](https://github.com/hugovk/pynacl/actions/runs/11213420559/job/31166435352#step:6:43)4, in filter
    raise exc
sphinx.errors.SphinxWarning: Calling get_html_theme_path is deprecated. If you are calling it to define html_theme_path, you are safe to remove that code.
```
