### PR TITLE
Add license to package classiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,6 +19,7 @@ authors = [
 description = "Python binding to the Networking and Cryptography (NaCl) library"
 license = {text = "Apache-2.0"}
 classifiers = [
+    "License :: OSI Approved :: Apache Software License",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Python :: Implementation :: PyPy",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Adding the license in the list of [package classifiers](https://pypi.org/classifiers/).

This is helpful for automated tools checking the license of packages, because the classifiers are a well-defined list, and tend to be well respected. This is contrary to the `license` metadata (which `PyNaCl` populates with `Apache-2.0` already), where the values used in various packages seems be all over the place.