### PR TITLE
Ensure that secretbox can accept any bytes-like object as parameter

### DIFF
--- a/src/nacl/bindings/crypto_secretbox.py
+++ b/src/nacl/bindings/crypto_secretbox.py
@@ -44,6 +44,9 @@ def crypto_secretbox(message: bytes, nonce: bytes, key: bytes) -> bytes:
     if len(nonce) != crypto_secretbox_NONCEBYTES:
         raise exc.ValueError("Invalid nonce")
 
+    nonce = ffi.from_buffer(nonce)
+    key = ffi.from_buffer(key)
+
     padded = b"\x00" * crypto_secretbox_ZEROBYTES + message
     ciphertext = ffi.new("unsigned char[]", len(padded))
 
@@ -71,6 +74,9 @@ def crypto_secretbox_open(
 
     if len(nonce) != crypto_secretbox_NONCEBYTES:
         raise exc.ValueError("Invalid nonce")
+
+    nonce = ffi.from_buffer(nonce)
+    key = ffi.from_buffer(key)
 
     padded = b"\x00" * crypto_secretbox_BOXZEROBYTES + ciphertext
     plaintext = ffi.new("unsigned char[]", len(padded))

--- a/tests/test_bindings.py
+++ b/tests/test_bindings.py
@@ -94,6 +94,25 @@ def test_secretbox_easy():
         )
 
 
+@pytest.mark.parametrize(
+    ("encoder", "decoder"),
+    [
+        [bytes, bytearray],
+        [bytearray, bytes],
+        [bytearray, bytearray],
+    ],
+)
+def test_secretbox_bytearray(encoder, decoder):
+    key = b"\x00" * c.crypto_secretbox_KEYBYTES
+    msg = b"message"
+    nonce = b"\x01" * c.crypto_secretbox_NONCEBYTES
+    ct = c.crypto_secretbox(encoder(msg), encoder(nonce), encoder(key))
+    assert len(ct) == len(msg) + c.crypto_secretbox_BOXZEROBYTES
+    assert tohex(ct) == "3ae84dfb89728737bd6e2c8cacbaf8af3d34cc1666533a"
+    msg2 = c.crypto_secretbox_open(decoder(ct), decoder(nonce), decoder(key))
+    assert msg2 == msg
+
+
 def test_secretbox_wrong_length():
     with pytest.raises(ValueError):
         c.crypto_secretbox(b"", b"", b"")


### PR DESCRIPTION
start to address #707, ensuring that secretbox can accept `bytearray`.

The issue I ran into in this case was that both mypy and pyright think that `bytearray` satisfy `bytes`. Taking the suggestion from #707 resolved this in tests.

Thank you for the library!