### PR TITLE
fix for #855 - Pydoc BadsignatureError moved to nacl.exceptions

### DIFF
--- a/src/nacl/signing.py
+++ b/src/nacl/signing.py
@@ -104,8 +104,8 @@ class VerifyKey(encoding.Encodable, StringFixer):
         """
         Verifies the signature of a signed message, returning the message
         if it has not been tampered with else raising
-        :class:`~nacl.signing.BadSignatureError`.
-
+        :class:`~nacl.exceptions.BadSignatureError`.
+        
         :param smessage: [:class:`bytes`] Either the original messaged or a
             signature and message concated together.
         :param signature: [:class:`bytes`] If an unsigned message is given for


### PR DESCRIPTION
#855 explains it
it's just a pydoc fix to the correct location of BadSignatureError, nothing special