### PR TITLE
Test with ARM64 Windows and also build wheels

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -102,13 +102,13 @@ jobs:
           - {ARCH: 'x86', SODIUM_ARCH: 'Win32'}
           - {ARCH: 'x64', SODIUM_ARCH: 'x64'}
         PYTHON:
-          - {VERSION: "3.7", NOXSESSION: "tests", SODIUM_MSVC_VERSION: "v142"}
-          - {VERSION: "3.8", NOXSESSION: "tests", SODIUM_MSVC_VERSION: "v142"}
-          - {VERSION: "3.9", NOXSESSION: "tests", SODIUM_MSVC_VERSION: "v142"}
-          - {VERSION: "3.10", NOXSESSION: "tests", SODIUM_MSVC_VERSION: "v142"}
-          - {VERSION: "3.11", NOXSESSION: "tests", SODIUM_MSVC_VERSION: "v142"}
-          - {VERSION: "3.12", NOXSESSION: "tests", SODIUM_MSVC_VERSION: "v142"}
-          - {VERSION: "3.13", NOXSESSION: "tests", SODIUM_MSVC_VERSION: "v142"}
+          - {VERSION: "3.7", NOXSESSION: "tests", SODIUM_MSVC_VERSION: "v143"}
+          - {VERSION: "3.8", NOXSESSION: "tests", SODIUM_MSVC_VERSION: "v143"}
+          - {VERSION: "3.9", NOXSESSION: "tests", SODIUM_MSVC_VERSION: "v143"}
+          - {VERSION: "3.10", NOXSESSION: "tests", SODIUM_MSVC_VERSION: "v143"}
+          - {VERSION: "3.11", NOXSESSION: "tests", SODIUM_MSVC_VERSION: "v143"}
+          - {VERSION: "3.12", NOXSESSION: "tests", SODIUM_MSVC_VERSION: "v143"}
+          - {VERSION: "3.13", NOXSESSION: "tests", SODIUM_MSVC_VERSION: "v143"}
     name: "Windows ${{ matrix.WINDOWS.ARCH }} ${{ matrix.PYTHON.VERSION }} ${{ matrix.PYTHON.NOXSESSION }}"
     steps:
       - uses: actions/checkout@v4.2.2
@@ -125,6 +125,7 @@ jobs:
         run: pip install nox coverage
       - name: Run tests
         run: |
+            call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" -no_logo -arch=${{ matrix.WINDOWS.ARCH }}
             set PYNACL_SODIUM_LIBRARY_NAME=sodium
             set PYNACL_SODIUM_STATIC=1
             set SODIUM_INSTALL=system

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -95,12 +95,12 @@ jobs:
           curl -o codecov.sh -f https://codecov.io/bash || curl -o codecov.sh -f https://codecov.io/bash || curl -o codecov.sh -f https://codecov.io/bash || curl -o codecov.sh -f https://codecov.io/bash || curl -o codecov.sh -f https://codecov.io/bash
           bash codecov.sh -n "Python ${{ matrix.PYTHON.VERSION }}${{ matrix.PYTHON.NOTE }} on macOS"
   windows:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.WINDOWS.IMAGE }}
     strategy:
       matrix:
         WINDOWS:
-          - {ARCH: 'x86', SODIUM_ARCH: 'Win32'}
-          - {ARCH: 'x64', SODIUM_ARCH: 'x64'}
+          - {ARCH: 'x86', SODIUM_ARCH: 'Win32', IMAGE: "windows-latest"}
+          - {ARCH: 'x64', SODIUM_ARCH: 'x64', IMAGE: "windows-latest"}
         PYTHON:
           - {VERSION: "3.7", NOXSESSION: "tests", SODIUM_MSVC_VERSION: "v143"}
           - {VERSION: "3.8", NOXSESSION: "tests", SODIUM_MSVC_VERSION: "v143"}
@@ -109,6 +109,13 @@ jobs:
           - {VERSION: "3.11", NOXSESSION: "tests", SODIUM_MSVC_VERSION: "v143"}
           - {VERSION: "3.12", NOXSESSION: "tests", SODIUM_MSVC_VERSION: "v143"}
           - {VERSION: "3.13", NOXSESSION: "tests", SODIUM_MSVC_VERSION: "v143"}
+        include:
+          - WINDOWS: {ARCH: 'arm64', SODIUM_ARCH: 'ARM64', IMAGE: "windows-11-arm"}
+            PYTHON: {VERSION: "3.11", NOXSESSION: "tests", SODIUM_MSVC_VERSION: "v143"}
+          - WINDOWS: {ARCH: 'arm64', SODIUM_ARCH: 'ARM64', IMAGE: "windows-11-arm"}
+            PYTHON: {VERSION: "3.12", NOXSESSION: "tests", SODIUM_MSVC_VERSION: "v143"}
+          - WINDOWS: {ARCH: 'arm64', SODIUM_ARCH: 'ARM64', IMAGE: "windows-11-arm"}
+            PYTHON: {VERSION: "3.13", NOXSESSION: "tests", SODIUM_MSVC_VERSION: "v143"}
     name: "Windows ${{ matrix.WINDOWS.ARCH }} ${{ matrix.PYTHON.VERSION }} ${{ matrix.PYTHON.NOXSESSION }}"
     steps:
       - uses: actions/checkout@v4.2.2

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -132,7 +132,7 @@ jobs:
           - {ARCH: 'x86', SODIUM_ARCH: 'Win32', VS_ARCH: 'x86'}
           - {ARCH: 'x64', SODIUM_ARCH: 'x64', VS_ARCH: 'amd64'}
         PYTHON:
-          - {VERSION: "3.9", SODIUM_MSVC_VERSION: "v142", "ABI_VERSION": "cp37"}
+          - {VERSION: "3.9", SODIUM_MSVC_VERSION: "v143", "ABI_VERSION": "cp37"}
     name: "${{ matrix.PYTHON.VERSION }} ${{ matrix.WINDOWS.ARCH }} ${{ matrix.PYTHON.ABI_VERSION }}"
     steps:
       - uses: actions/checkout@v4.2.2
@@ -160,7 +160,7 @@ jobs:
       - name: Build the wheel
         run: |
           mkdir wheelhouse
-          call "C:\Program Files (x86)\Microsoft Visual Studio\2019\Enterprise\Common7\Tools\VsDevCmd.bat" -no_logo -arch=${{ matrix.WINDOWS.VS_ARCH }}
+          call "C:\Program Files\Microsoft Visual Studio\2022\Enterprise\Common7\Tools\VsDevCmd.bat" -no_logo -arch=${{ matrix.WINDOWS.VS_ARCH }}
           python -m build --wheel --config-setting=--build-option=--py-limited-api=${{ matrix.PYTHON.ABI_VERSION }}
           mv dist/pynacl*.whl wheelhouse/
         shell: cmd

--- a/.github/workflows/wheel-builder.yml
+++ b/.github/workflows/wheel-builder.yml
@@ -125,14 +125,16 @@ jobs:
           name: "pynacl-${{ github.event.inputs.version }}-macOS-${{ matrix.PYTHON.VERSION }}"
           path: pynacl-wheelhouse/
   windows:
-    runs-on: windows-latest
+    runs-on: ${{ matrix.WINDOWS.IMAGE }}
     strategy:
       matrix:
-        WINDOWS:
-          - {ARCH: 'x86', SODIUM_ARCH: 'Win32', VS_ARCH: 'x86'}
-          - {ARCH: 'x64', SODIUM_ARCH: 'x64', VS_ARCH: 'amd64'}
-        PYTHON:
-          - {VERSION: "3.9", SODIUM_MSVC_VERSION: "v143", "ABI_VERSION": "cp37"}
+        include:
+          - WINDOWS: {ARCH: 'x86', SODIUM_ARCH: 'Win32', VS_ARCH: 'x86', IMAGE: 'windows-latest'}
+            PYTHON: {VERSION: '3.9', ABI_VERSION: 'cp37', SODIUM_MSVC_VERSION: 'v143'}
+          - WINDOWS: {ARCH: 'x64', SODIUM_ARCH: 'x64', VS_ARCH: 'amd64', IMAGE: 'windows-latest'}
+            PYTHON: {VERSION: '3.9', ABI_VERSION: 'cp37', SODIUM_MSVC_VERSION: 'v143'}
+          - WINDOWS: {ARCH: 'arm64', SODIUM_ARCH: 'ARM64', VS_ARCH: 'arm64', IMAGE: 'windows-11-arm'}
+            PYTHON: {VERSION: '3.11', ABI_VERSION: 'cp37', SODIUM_MSVC_VERSION: 'v143'}
     name: "${{ matrix.PYTHON.VERSION }} ${{ matrix.WINDOWS.ARCH }} ${{ matrix.PYTHON.ABI_VERSION }}"
     steps:
       - uses: actions/checkout@v4.2.2


### PR DESCRIPTION
Since GitHub Actions now has ARM64 Windows runners we can test and build natively.

* Python ARM64 builds are only available since 3.11, so skip older versions for ARM64 everywhere.
* Sodium has arm64 builds only in a later binary release, so update the tarball. Downloaded from here: https://download.libsodium.org/libsodium/releases/
* The arm64 sodium builds are only available for v143, so just bump to v143 everywhere to keep things simple.