### PR TITLE
CI: Stop using ubuntu-20.04

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   linux:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     strategy:
       fail-fast: false
       matrix:


### PR DESCRIPTION
It's going away: https://github.com/actions/runner-images/issues/11101

Switch to ubuntu-22.04 instead. Switching to ubuntu-24.04 is only blocked
by Python 3.7 not being available there.