### PR TITLE
fix: PyNaCl bundled libsodium config for android

### DIFF
--- a/src/libsodium/configure
+++ b/src/libsodium/configure
@@ -22692,11 +22692,19 @@ then :
   printf "%s\n" "#define HAVE_MEMSET_S 1" >>confdefs.h
 
 fi
-ac_fn_c_check_func "$LINENO" "explicit_bzero" "ac_cv_func_explicit_bzero"
-if test "x$ac_cv_func_explicit_bzero" = xyes
-then :
+# On Android/Bionic none of these exist in libc.
+case "$host_os" in
+  *android*)
+    ac_cv_func_explicit_bzero=no
+    ac_cv_func_memset_s=no
+    ac_cv_func_memset_explicit=no
+    ;;
+  *)
+    ac_fn_c_check_func "$LINENO" "explicit_bzero" "ac_cv_func_explicit_bzero"
+    ;;
+esac
+if test "x$ac_cv_func_explicit_bzero" = xyes; then
   printf "%s\n" "#define HAVE_EXPLICIT_BZERO 1" >>confdefs.h
-
 fi
 ac_fn_c_check_func "$LINENO" "memset_explicit" "ac_cv_func_memset_explicit"
 if test "x$ac_cv_func_memset_explicit" = xyes


### PR DESCRIPTION
Fixes PyNaCl wheel build failure on android hosts because Android/Bionic does not have these in it's libc.

On Android/Bionic these functions are not provided by libc (explicit_bzero, memset_s,
memset_explicit). This commit forces the configure cache variables for those functions to "no"
when building for Android, ensuring the generated config headers will not
advertise availability and the bundled libsodium will use its internal secure‑wipe
implementation fixing the build.