### PR TITLE
Drop support for PyPy 3.10

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
           - {VERSION: "3.13", NOXSESSION: "docs"}
           - {VERSION: "3.13", NOXSESSION: "meta"}
           - {VERSION: "3.13", NOXSESSION: "mypy"}
-          - {VERSION: "pypy-3.10", NOXSESSION: "tests"}
           - {VERSION: "pypy-3.11", NOXSESSION: "tests"}
           - {VERSION: "3.8", NOXSESSION: "tests"}
           - {VERSION: "3.9", NOXSESSION: "tests"}


### PR DESCRIPTION
Removed pypy-3.10 from the CI test sessions.